### PR TITLE
feat: structured `## Verdict: <token>` parser contract (#1)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -66,16 +66,14 @@ issue 取得と recall の **後**、ブランチ作成の **前** に走りま�
 
 ### Verdict 行の規約
 
-レビュアの skill は、応答末尾に以下のいずれかの行を出力すること：
+レビュアの skill は、応答末尾に、次のうち **1行だけ** を出力すること：
 
-```
-## Verdict: green
-## Verdict: yellow
-## Verdict: red
-## Verdict: decline   # gate1 (/ask) のみ — routing 昇格シグナル
-## Verdict: pass      # /audit のみ
-## Verdict: fail      # /audit のみ
-```
+- `## Verdict: green`
+- `## Verdict: yellow`
+- `## Verdict: red`
+- `## Verdict: decline`  &nbsp;&nbsp;— gate1 (`/ask`) のみ、routing 昇格シグナル
+- `## Verdict: pass`  &nbsp;&nbsp;— `/audit` のみ
+- `## Verdict: fail`  &nbsp;&nbsp;— `/audit` のみ
 
 ルール：
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -47,7 +47,7 @@
 issue 取得と recall の **後**、ブランチ作成の **前** に走ります。戦略：
 
 1. まず `/claude-c-suite:ask`（単一視点ルータ）を呼ぶ。軽量・高速で、専門1分野で済む issue に最適。
-2. `/ask` が応答末尾に `## Verdict: decline` を出力した場合、`/claude-c-suite:ceo` に昇格して3視点 synthesis を実行。（`decline` は `## Verdict:` 行の5番目の値として扱われ、別チャネルではない。応答本文に "decline" や "escalate" という単語が出てきても、それはレビュアの推論の一部であり routing シグナルではない — 構造化された verdict 行のみがカウントされる。）
+2. `/ask` 応答内で最後に出現した `## Verdict:` 行のトークンが `decline` の場合、`/claude-c-suite:ceo` に昇格して3視点 synthesis を実行。（`decline` は `## Verdict:` 行の5番目の値として扱われ、別チャネルではない。応答本文に "decline" や "escalate" という単語が出てきても、それはレビュアの推論の一部であり routing シグナルではない — 構造化された verdict 行のみがカウントされる。）
 3. レビュアの応答末尾の `## Verdict: green|yellow|red` 行から verdict を解析する。構造化行が canonical で last-wins、case は正規化、末尾の句読点は許容。キーワードヒューリスティックは構造化行が無い場合の **fallback のみ** で、warn ログを emit して soft-deprecation の追跡が可能。
 4. **green** → 続行 / **yellow** → ユーザー確認 / **red** → abort（`force` で override 可）
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -47,8 +47,8 @@
 issue 取得と recall の **後**、ブランチ作成の **前** に走ります。戦略：
 
 1. まず `/claude-c-suite:ask`（単一視点ルータ）を呼ぶ。軽量・高速で、専門1分野で済む issue に最適。
-2. `/ask` が decline（`DECLINE` / `needs synthesis` / `requires multiple lenses` / `escalate` を出力に含む）した場合、`/claude-c-suite:ceo` に昇格して3視点 synthesis を実行。
-3. レビュアの応答末尾の `## Verdict: green|yellow|red` 行から verdict を解析（無ければヒューリスティック）。
+2. `/ask` が応答末尾に `## Verdict: decline` を出力した場合、`/claude-c-suite:ceo` に昇格して3視点 synthesis を実行。（`decline` は `## Verdict:` 行の5番目の値として扱われ、別チャネルではない。応答本文に "decline" や "escalate" という単語が出てきても、それはレビュアの推論の一部であり routing シグナルではない — 構造化された verdict 行のみがカウントされる。）
+3. レビュアの応答末尾の `## Verdict: green|yellow|red` 行から verdict を解析する。構造化行が canonical で last-wins、case は正規化、末尾の句読点は許容。キーワードヒューリスティックは構造化行が無い場合の **fallback のみ** で、warn ログを emit して soft-deprecation の追跡が可能。
 4. **green** → 続行 / **yellow** → ユーザー確認 / **red** → abort（`force` で override 可）
 
 ### Gate 2 — PR 作成直前のレビューバッテリー（`/gh-issue-driven:ship`）
@@ -66,13 +66,27 @@ issue 取得と recall の **後**、ブランチ作成の **前** に走りま�
 
 ### Verdict 行の規約
 
-レビュアの skill には、応答末尾に以下を含めることを推奨：
+レビュアの skill は、応答末尾に以下のいずれかの行を出力すること：
 
 ```
 ## Verdict: green
+## Verdict: yellow
+## Verdict: red
+## Verdict: decline   # gate1 (/ask) のみ — routing 昇格シグナル
+## Verdict: pass      # /audit のみ
+## Verdict: fail      # /audit のみ
 ```
 
-（または `yellow` / `red` / `/audit` なら `pass` / `fail`）。`gh-issue-driven` はこの行を最優先で解釈し、無ければキーワードヒューリスティックにフォールバックします。
+ルール：
+
+- **構造化行が canonical**。`gh-issue-driven` はこの行を最優先で解釈する。
+- **last-wins**: 応答中に複数行ある場合、最後の出現が勝つ（"最初は red と思ったが結局 green" のような自然な記述に対応）。
+- **case insensitive**: `Green` / `green` / `GREEN` はすべて `green` に正規化される。
+- **末尾の句読点 OK**: `## Verdict: green.` のような形式も `\b<token>\b` で許容される。
+- **キーワードヒューリスティックは fallback のみ**: 構造化行が無い場合だけ走る。fallback したときは `verdict_parser=heuristic` という warn ログを emit するので、ヒューリスティック完全廃止 (v0.4) の判断材料として追跡可能。
+- **`decline` は gate1 routing 専用**: 5番目の verdict 値で、別チャネルではない。本文中に "decline" の単語が出ても、それは routing シグナルではなくレビュアの推論。
+
+`claude-c-suite` / `claude-phd-panel` などの reviewer skill を保守している場合、この行を出力するように改修すれば統合がよりクリーンになる。
 
 ---
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -66,7 +66,7 @@ issue 取得と recall の **後**、ブランチ作成の **前** に走りま�
 
 ### Verdict 行の規約
 
-レビュアの skill は、応答末尾に、次のうち **1行だけ** を出力すること：
+レビュアの skill は、応答末尾に最終的な `## Verdict:` 行を出力すること。トークンは次のいずれか：
 
 - `## Verdict: green`
 - `## Verdict: yellow`
@@ -74,6 +74,8 @@ issue 取得と recall の **後**、ブランチ作成の **前** に走りま�
 - `## Verdict: decline`  &nbsp;&nbsp;— gate1 (`/ask`) のみ、routing 昇格シグナル
 - `## Verdict: pass`  &nbsp;&nbsp;— `/audit` のみ
 - `## Verdict: fail`  &nbsp;&nbsp;— `/audit` のみ
+
+（応答中に複数の `## Verdict:` 行が現れた場合は last-wins が適用される — 下記ルール参照。）
 
 ルール：
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -47,7 +47,7 @@
 issue 取得と recall の **後**、ブランチ作成の **前** に走ります。戦略：
 
 1. まず `/claude-c-suite:ask`（単一視点ルータ）を呼ぶ。軽量・高速で、専門1分野で済む issue に最適。
-2. `/ask` 応答内で最後に出現した `## Verdict:` 行のトークンが `decline` の場合、`/claude-c-suite:ceo` に昇格して3視点 synthesis を実行。（`decline` は `## Verdict:` 行の5番目の値として扱われ、別チャネルではない。応答本文に "decline" や "escalate" という単語が出てきても、それはレビュアの推論の一部であり routing シグナルではない — 構造化された verdict 行のみがカウントされる。）
+2. `/ask` 応答内で最後に出現した `## Verdict:` 行のトークンが `decline` の場合、`/claude-c-suite:ceo` に昇格して3視点 synthesis を実行。（`decline` は同じ `## Verdict:` 行で使われる gate1 専用トークンであり、別チャネルではない。応答本文に "decline" や "escalate" という単語が出てきても、それはレビュアの推論の一部であり routing シグナルではない — 構造化された verdict 行のみがカウントされる。）
 3. レビュアの応答末尾の `## Verdict: green|yellow|red` 行から verdict を解析する。構造化行が canonical で last-wins、case は正規化、末尾の句読点は許容。キーワードヒューリスティックは構造化行が無い場合の **fallback のみ** で、warn ログを emit して soft-deprecation の追跡が可能。
 4. **green** → 続行 / **yellow** → ユーザー確認 / **red** → abort（`force` で override 可）
 
@@ -84,7 +84,7 @@ issue 取得と recall の **後**、ブランチ作成の **前** に走りま�
 - **case insensitive**: `Green` / `green` / `GREEN` はすべて `green` に正規化される。
 - **末尾の句読点 OK**: `## Verdict: green.` のような形式も `\b<token>\b` で許容される。
 - **キーワードヒューリスティックは fallback のみ**: 構造化行が無い場合だけ走る。fallback したときは `verdict_parser=heuristic` という warn ログを emit するので、ヒューリスティック完全廃止 (v0.4) の判断材料として追跡可能。
-- **`decline` は gate1 routing 専用**: 5番目の verdict 値で、別チャネルではない。本文中に "decline" の単語が出ても、それは routing シグナルではなくレビュアの推論。
+- **`decline` は gate1 routing 専用トークン**: 別チャネルではない。本文中に "decline" の単語が出ても、それは routing シグナルではなくレビュアの推論。
 
 `claude-c-suite` / `claude-phd-panel` などの reviewer skill を保守している場合、この行を出力するように改修すれば統合がよりクリーンになる。
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Runs **after** the implementation, **before** the PR is created. Four reviewers 
 
 ### Verdict line convention
 
-Reviewer skills must end their response with **exactly one** of the following structured verdict lines:
+Reviewer skills must end their response with a final `## Verdict:` line. The token must be one of:
 
 - `## Verdict: green`
 - `## Verdict: yellow`
@@ -74,6 +74,8 @@ Reviewer skills must end their response with **exactly one** of the following st
 - `## Verdict: decline`  &nbsp;&nbsp;— gate1 (`/ask`) only; routing escalation signal
 - `## Verdict: pass`  &nbsp;&nbsp;— `/audit` only
 - `## Verdict: fail`  &nbsp;&nbsp;— `/audit` only
+
+(If multiple `## Verdict:` lines appear in the response, last-wins applies — see Rules below.)
 
 Rules:
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The whole flow is bracketed by `kagura-memory` `session-start` and `session-summ
 Runs **after** the issue is fetched and recall is done, **before** the branch is created. Strategy:
 
 1. Invoke `/claude-c-suite:ask` first — a single-lens auto-router. Cheap, fast, perfect for issues that need only one expert perspective.
-2. If `/ask` ends its response with `## Verdict: decline`, escalate to `/claude-c-suite:ceo` for full 3-lens synthesis. (`decline` is treated as a 5th value of the same `## Verdict:` line, not a separate channel — only the structured line counts. Free-form mentions of "decline" or "escalate" inside the analysis body are part of the reviewer's reasoning, not routing instructions.)
+2. If the last `## Verdict:` line's token is `decline`, escalate to `/claude-c-suite:ceo` for full 3-lens synthesis. (`decline` is treated as a 5th value of the same `## Verdict:` line, not a separate channel — only the structured line counts. Free-form mentions of "decline" or "escalate" inside the analysis body are part of the reviewer's reasoning, not routing instructions.)
 3. Parse the verdict from a `## Verdict: green|yellow|red` line at the end of the reviewer's response. The structured line is canonical and last-wins; case is normalized; trailing punctuation is tolerated. A keyword heuristic is the **fallback only** when no structured line is present, and emits a warn-level log so soft-deprecation can be tracked.
 4. **green** → continue. **yellow** → ask the user to confirm. **red** → abort unless `force`.
 

--- a/README.md
+++ b/README.md
@@ -66,16 +66,14 @@ Runs **after** the implementation, **before** the PR is created. Four reviewers 
 
 ### Verdict line convention
 
-Reviewer skills must end their response with one of these structured verdict lines:
+Reviewer skills must end their response with **exactly one** of the following structured verdict lines:
 
-```
-## Verdict: green
-## Verdict: yellow
-## Verdict: red
-## Verdict: decline   # gate1 (/ask) only — routing escalation signal
-## Verdict: pass      # /audit only
-## Verdict: fail      # /audit only
-```
+- `## Verdict: green`
+- `## Verdict: yellow`
+- `## Verdict: red`
+- `## Verdict: decline`  &nbsp;&nbsp;— gate1 (`/ask`) only; routing escalation signal
+- `## Verdict: pass`  &nbsp;&nbsp;— `/audit` only
+- `## Verdict: fail`  &nbsp;&nbsp;— `/audit` only
 
 Rules:
 

--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ The whole flow is bracketed by `kagura-memory` `session-start` and `session-summ
 Runs **after** the issue is fetched and recall is done, **before** the branch is created. Strategy:
 
 1. Invoke `/claude-c-suite:ask` first — a single-lens auto-router. Cheap, fast, perfect for issues that need only one expert perspective.
-2. If `/ask` declines (emits `DECLINE`, `needs synthesis`, `requires multiple lenses`, or `escalate`), escalate to `/claude-c-suite:ceo` for full 3-lens synthesis.
-3. Parse the verdict from a `## Verdict: green|yellow|red` line at the end of the reviewer's response (with heuristic fallback).
+2. If `/ask` ends its response with `## Verdict: decline`, escalate to `/claude-c-suite:ceo` for full 3-lens synthesis. (`decline` is treated as a 5th value of the same `## Verdict:` line, not a separate channel — only the structured line counts. Free-form mentions of "decline" or "escalate" inside the analysis body are part of the reviewer's reasoning, not routing instructions.)
+3. Parse the verdict from a `## Verdict: green|yellow|red` line at the end of the reviewer's response. The structured line is canonical and last-wins; case is normalized; trailing punctuation is tolerated. A keyword heuristic is the **fallback only** when no structured line is present, and emits a warn-level log so soft-deprecation can be tracked.
 4. **green** → continue. **yellow** → ask the user to confirm. **red** → abort unless `force`.
 
 ### Gate 2 — Pre-PR review battery (`/gh-issue-driven:ship`)
@@ -66,13 +66,27 @@ Runs **after** the implementation, **before** the PR is created. Four reviewers 
 
 ### Verdict line convention
 
-Reviewer skills are encouraged to end their response with:
+Reviewer skills must end their response with one of these structured verdict lines:
 
 ```
 ## Verdict: green
+## Verdict: yellow
+## Verdict: red
+## Verdict: decline   # gate1 (/ask) only — routing escalation signal
+## Verdict: pass      # /audit only
+## Verdict: fail      # /audit only
 ```
 
-(or `yellow`, `red`, or `pass`/`fail` for `/audit`). `gh-issue-driven` looks for this line first and falls back to keyword heuristics if it's missing. If you maintain a c-suite or phd-panel skill, adding this line makes integration cleaner.
+Rules:
+
+- **The structured line is canonical.** `gh-issue-driven` parses this line first.
+- **Last-wins**: if multiple `## Verdict:` lines appear in the response, the **last** occurrence is used (so reviewers can naturally write "at first I thought red, but actually green").
+- **Case insensitive**: `Green` / `green` / `GREEN` all normalize to `green`.
+- **Trailing punctuation tolerated**: `## Verdict: green.` is accepted (`\b<token>\b` regex).
+- **Heuristic is fallback only**: if no structured line is present, a keyword heuristic runs and emits a `verdict_parser=heuristic` warn log so its usage can be tracked toward eventual removal in v0.4.
+- **`decline` is gate1-routing-only**: it's a 5th value of the same `## Verdict:` line, not a separate channel. Free-form mentions of "decline" inside the analysis body are reviewer reasoning, not routing signals.
+
+If you maintain a `claude-c-suite` or `claude-phd-panel` reviewer skill, emitting this line on every reviewer response is the cleanest integration.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The whole flow is bracketed by `kagura-memory` `session-start` and `session-summ
 Runs **after** the issue is fetched and recall is done, **before** the branch is created. Strategy:
 
 1. Invoke `/claude-c-suite:ask` first — a single-lens auto-router. Cheap, fast, perfect for issues that need only one expert perspective.
-2. If the last `## Verdict:` line's token is `decline`, escalate to `/claude-c-suite:ceo` for full 3-lens synthesis. (`decline` is treated as a 5th value of the same `## Verdict:` line, not a separate channel — only the structured line counts. Free-form mentions of "decline" or "escalate" inside the analysis body are part of the reviewer's reasoning, not routing instructions.)
+2. If the last `## Verdict:` line's token is `decline`, escalate to `/claude-c-suite:ceo` for full 3-lens synthesis. (`decline` is an additional gate1-only token on the same `## Verdict:` line, not a separate channel — only the structured line counts. Free-form mentions of "decline" or "escalate" inside the analysis body are part of the reviewer's reasoning, not routing instructions.)
 3. Parse the verdict from a `## Verdict: green|yellow|red` line at the end of the reviewer's response. The structured line is canonical and last-wins; case is normalized; trailing punctuation is tolerated. A keyword heuristic is the **fallback only** when no structured line is present, and emits a warn-level log so soft-deprecation can be tracked.
 4. **green** → continue. **yellow** → ask the user to confirm. **red** → abort unless `force`.
 
@@ -84,7 +84,7 @@ Rules:
 - **Case insensitive**: `Green` / `green` / `GREEN` all normalize to `green`.
 - **Trailing punctuation tolerated**: `## Verdict: green.` is accepted (`\b<token>\b` regex).
 - **Heuristic is fallback only**: if no structured line is present, a keyword heuristic runs and emits a `verdict_parser=heuristic` warn log so its usage can be tracked toward eventual removal in v0.4.
-- **`decline` is gate1-routing-only**: it's a 5th value of the same `## Verdict:` line, not a separate channel. Free-form mentions of "decline" inside the analysis body are reviewer reasoning, not routing signals.
+- **`decline` is gate1-routing-only**: it's a valid value on the same `## Verdict:` line for gate1 responses, not a separate channel. Free-form mentions of "decline" inside the analysis body are reviewer reasoning, not routing signals.
 
 If you maintain a `claude-c-suite` or `claude-phd-panel` reviewer skill, emitting this line on every reviewer response is the cleanest integration.
 

--- a/commands/config.md
+++ b/commands/config.md
@@ -37,7 +37,6 @@ This command is **mostly read-only**. The single mutating action is `init`, whic
   "gate1": {
     "primary": "/claude-c-suite:ask",
     "fallback": "/claude-c-suite:ceo",
-    "decline_tokens": ["DECLINE", "needs synthesis", "requires multiple lenses", "escalate"],
     "yellow_continue_requires_confirm": true
   },
   "gate2": {

--- a/commands/ship.md
+++ b/commands/ship.md
@@ -91,10 +91,13 @@ Construct one shared block all four reviewers will receive:
 <contents of /tmp/gh-issue-driven.diff>
 
 ## Your task
-Review this change. End with exactly one line:
+Review this change. End your response with a final `## Verdict:` line (if multiple
+`## Verdict:` lines appear earlier in the response, the LAST one wins). The token must be one of:
 "## Verdict: green" | "## Verdict: yellow" | "## Verdict: red"
-For /audit specifically, end with:
+For /audit specifically, the token must be one of:
 "## Verdict: pass" | "## Verdict: fail"
+You can naturally revise mid-analysis ("at first I thought yellow, but actually green") —
+the last `## Verdict:` line is what counts.
 ```
 
 ### 6. Gate 2 — parallel reviewer battery

--- a/commands/ship.md
+++ b/commands/ship.md
@@ -115,9 +115,17 @@ If any of these skills is not installed, mark its slot `unknown`, print a warnin
 
 Determine `AUDIT_VERDICT` from `AUDIT_OUT` in this priority order:
 
-1. **Structured verdict line**: a line matching `^##\s*Verdict:\s*(pass|fail)\b` (case-insensitive). If found, use it.
-2. **Skill error signal**: if the Skill tool returned an error/non-zero indication for `/audit`, treat as `fail`.
-3. **Heuristic fallback**: tokens `BLOCKER`, `failed conformance`, `MUST FIX` in the markdown → `fail`. Otherwise `pass`.
+1. **Structured verdict line (preferred, canonical)**: scan for **all** lines matching
+   `^\s*##\s*Verdict:\s*(pass|fail)\b` (case-insensitive). If one or more match, take the **LAST**
+   occurrence (last-wins), lowercase, and use it. Trailing punctuation is tolerated; case is
+   normalized via `.lower()`.
+2. **Skill error signal**: if the Skill tool returned an error/non-zero indication for `/audit`
+   AND no structured verdict line was found, treat as `fail`. (A clean structured `pass` line is
+   never overridden by a downstream error after the fact.)
+3. **Heuristic fallback** — only runs when no structured line and no skill error. Emit a single
+   warn-level log line `verdict_parser=heuristic gate=audit reason=no_structured_line` so the
+   soft-deprecation can be tracked. Tokens `BLOCKER`, `failed conformance`, `MUST FIX` in the
+   markdown → `fail`. Otherwise `pass`.
 
 **If `AUDIT_VERDICT == fail`**: abort PR creation entirely. Even with `FORCE`. Save the audit output to the gate2 markdown file. Persist `gate2.audit=fail, gate2.verdict=red` in the state. Print:
 
@@ -133,13 +141,20 @@ Then exit. Do not push, do not create the PR.
 
 ### 8. Advisor aggregation
 
-For each of `CSO_OUT`, `QA_OUT`, `CTO_OUT`, classify into `green | yellow | red` using this priority:
+For each of `CSO_OUT`, `QA_OUT`, `CTO_OUT`, classify into `green | yellow | red` using this contract:
 
-1. Structured `^##\s*Verdict:\s*(green|yellow|red)\b` line if present.
-2. Heuristic:
-   - **red**: `BLOCKER`, `must fix before`, `red flag`, `do not proceed`, `Critical:` 3+ times, `## Verdict: red` markers.
+1. **Structured verdict line (preferred, canonical)**: scan for **all** lines matching
+   `^\s*##\s*Verdict:\s*(green|yellow|red)\b` (case-insensitive). If one or more match, take the
+   **LAST** occurrence (last-wins), lowercase, and use it.
+2. **Heuristic fallback** — only runs when no structured line was found. Emit one warn-level log
+   line per advisor: `verdict_parser=heuristic gate=gate2 advisor=<name> reason=no_structured_line`.
+   - **red**: `BLOCKER`, `must fix before`, `red flag`, `do not proceed`, `Critical:` 3+ times.
    - **yellow**: `WARN`, `consider`, `recommend`, `Warning:` 1–2 times.
    - **green**: none of the above.
+
+Note: gate2 advisors do **not** support a `decline` token — declination is a gate1-only routing
+concept. An advisor that cannot meaningfully assess should still emit `## Verdict: yellow` with a
+note in the body explaining the limitation, rather than declining.
 
 Compute `GATE2_VERDICT`:
 - any red → `red`

--- a/commands/start.md
+++ b/commands/start.md
@@ -161,12 +161,16 @@ Review this issue from a design-time perspective:
 - Are the requirements clear and well-scoped?
 - Are there obvious risks, edge cases, or missing constraints?
 - Is the implied approach reasonable, or should the implementer reconsider?
-- If this question genuinely needs synthesis across multiple expert lenses, DECLINE
-  routing and emit one of these tokens at the start of your response:
-  "DECLINE", "needs synthesis", "requires multiple lenses", or "escalate".
+- If this question genuinely needs synthesis across multiple expert lenses, decline
+  routing by emitting `## Verdict: decline` as your final verdict line. Do NOT use
+  free-form keywords (DECLINE, needs synthesis, escalate, etc.) anywhere in your
+  reasoning to signal routing — only the structured `## Verdict:` line counts.
 
-End your response with exactly one line:
-"## Verdict: green" | "## Verdict: yellow" | "## Verdict: red"
+End your response with exactly one line, the canonical verdict:
+"## Verdict: green" | "## Verdict: yellow" | "## Verdict: red" | "## Verdict: decline"
+
+Where `decline` means: "this question needs multiple lenses — please escalate to /ceo".
+The last `## Verdict:` line in your response wins (you can revise mid-analysis).
 ```
 
 ### 9. Gate 1 cascade — invoke `/ask` first
@@ -177,21 +181,27 @@ Capture the full skill output as `ASK_OUTPUT`.
 
 ### 10. Detect decline and escalate if needed
 
-Scan `ASK_OUTPUT` for a **structured decline verdict** — a line matching the regex
-`^\s*##\s*Verdict:\s*decline\b` (case-insensitive). If multiple match, the **last one wins**.
+Scan `ASK_OUTPUT` for **all** lines matching `^\s*##\s*Verdict:\s*(green|yellow|red|decline)\b`
+(case-insensitive). If one or more match, take the **LAST** occurrence (last-wins) and lowercase
+the captured token. This is the same scan-and-take-last rule used in step 11 — decline is just
+a 5th valid token on the same line, not a separate channel.
 
 Free-form mentions of `decline`, `needs synthesis`, `escalate`, etc. inside the analysis body
 are **not** decline signals — they are the reviewer's reasoning. Only the structured verdict
-line counts. (This is the same contract used in step 11 for color verdicts; decline is just
-a 5th valid token on the same line, not a separate channel.)
+line counts. The escalation check operates on the LAST `## Verdict:` line's token across the
+**full token set**, so a reviewer who writes "I first thought `## Verdict: decline` but on
+reflection `## Verdict: green`" correctly resolves to green and does NOT escalate.
 
-- **If a `## Verdict: decline` line is present**: escalate.
+- **If the last token is `decline`**: escalate.
 
   > **Invoke the `/claude-c-suite:ceo` skill via the Skill tool**, passing the same gate1 prompt block plus a one-line note `(Escalated from /ask: <first 200 chars of ask output>)`. Wait for the full markdown response.
 
   Use the `/ceo` output as `GATE1_OUTPUT`. Set `GATE1_REVIEWER="ask"` and `GATE1_ESCALATED_TO="ceo"`.
 
-- **Otherwise**: use `ASK_OUTPUT` as `GATE1_OUTPUT`. Set `GATE1_REVIEWER="ask"` and `GATE1_ESCALATED_TO=null`.
+- **Otherwise** (the last token is `green`/`yellow`/`red`, OR no structured line was found at all):
+  use `ASK_OUTPUT` as `GATE1_OUTPUT`. Set `GATE1_REVIEWER="ask"` and `GATE1_ESCALATED_TO=null`.
+  The verdict will be parsed in step 11 (which re-scans the same lines using the same last-wins
+  contract — duplication is intentional for v0.1.1; #14 / future refactor will share the parser).
 
 If the `/ask` skill is not installed, fall back directly to `/ceo`. If both are missing, log a loud warning `gate1 skipped: claude-c-suite not installed`, set `GATE1_VERDICT="unknown"`, and continue (do not abort).
 

--- a/commands/start.md
+++ b/commands/start.md
@@ -166,12 +166,13 @@ Review this issue from a design-time perspective:
   free-form keywords (DECLINE, needs synthesis, escalate, etc.) anywhere in your
   reasoning to signal routing — only the structured `## Verdict:` line counts.
 
-End your response with exactly one final canonical verdict line:
+End your response with a final `## Verdict:` line (if multiple `## Verdict:` lines
+appear earlier in the response, the LAST one wins). The token must be one of:
 "## Verdict: green" | "## Verdict: yellow" | "## Verdict: red" | "## Verdict: decline"
 
 Where `decline` means: "this question needs multiple lenses — please escalate to /ceo".
-You may revise your assessment earlier in the response, but if you emit multiple
-`## Verdict:` lines, only the final one is authoritative and it must be the last line.
+You can naturally revise mid-analysis ("at first I thought decline, but actually green") —
+the last `## Verdict:` line is what counts.
 ```
 
 ### 9. Gate 1 cascade — invoke `/ask` first
@@ -184,8 +185,8 @@ Capture the full skill output as `ASK_OUTPUT`.
 
 Scan `ASK_OUTPUT` for **all** lines matching `^\s*##\s*Verdict:\s*(green|yellow|red|decline)\b`
 (case-insensitive). If one or more match, take the **LAST** occurrence (last-wins) and lowercase
-the captured token. This is the same scan-and-take-last rule used in step 11 — `decline` is an
-additional valid token on the same line for gate1, not a separate channel.
+the captured token. This uses the same last-wins structured-line approach as step 11, but with an
+expanded token set here to include `decline`; it is not a separate channel.
 
 Free-form mentions of `decline`, `needs synthesis`, `escalate`, etc. inside the analysis body
 are **not** decline signals — they are the reviewer's reasoning. Only the structured verdict

--- a/commands/start.md
+++ b/commands/start.md
@@ -166,11 +166,12 @@ Review this issue from a design-time perspective:
   free-form keywords (DECLINE, needs synthesis, escalate, etc.) anywhere in your
   reasoning to signal routing — only the structured `## Verdict:` line counts.
 
-End your response with exactly one line, the canonical verdict:
+End your response with exactly one final canonical verdict line:
 "## Verdict: green" | "## Verdict: yellow" | "## Verdict: red" | "## Verdict: decline"
 
 Where `decline` means: "this question needs multiple lenses — please escalate to /ceo".
-The last `## Verdict:` line in your response wins (you can revise mid-analysis).
+You may revise your assessment earlier in the response, but if you emit multiple
+`## Verdict:` lines, only the final one is authoritative and it must be the last line.
 ```
 
 ### 9. Gate 1 cascade — invoke `/ask` first
@@ -183,8 +184,8 @@ Capture the full skill output as `ASK_OUTPUT`.
 
 Scan `ASK_OUTPUT` for **all** lines matching `^\s*##\s*Verdict:\s*(green|yellow|red|decline)\b`
 (case-insensitive). If one or more match, take the **LAST** occurrence (last-wins) and lowercase
-the captured token. This is the same scan-and-take-last rule used in step 11 — decline is just
-a 5th valid token on the same line, not a separate channel.
+the captured token. This is the same scan-and-take-last rule used in step 11 — `decline` is an
+additional valid token on the same line for gate1, not a separate channel.
 
 Free-form mentions of `decline`, `needs synthesis`, `escalate`, etc. inside the analysis body
 are **not** decline signals — they are the reviewer's reasoning. Only the structured verdict
@@ -194,7 +195,14 @@ reflection `## Verdict: green`" correctly resolves to green and does NOT escalat
 
 - **If the last token is `decline`**: escalate.
 
-  > **Invoke the `/claude-c-suite:ceo` skill via the Skill tool**, passing the same gate1 prompt block plus a one-line note `(Escalated from /ask: <first 200 chars of ask output>)`. Wait for the full markdown response.
+  > **Invoke the `/claude-c-suite:ceo` skill via the Skill tool**, passing the same gate1 prompt block plus this two-line footer:
+  >
+  > ```
+  > (Escalated from /ask: <first 200 chars of ask output>)
+  > Note: as the escalation target, end your response with `## Verdict: green|yellow|red` only — `decline` is not valid for /ceo (you ARE the escalation target, there is no further escalation).
+  > ```
+  >
+  > Wait for the full markdown response. The `/ceo` response is then parsed by step 11, which only recognizes `green|yellow|red`; if `/ceo` ignores the constraint and emits `decline`, the structured path will not match and the heuristic fallback will run with a warn log — that signal is what we want to track.
 
   Use the `/ceo` output as `GATE1_OUTPUT`. Set `GATE1_REVIEWER="ask"` and `GATE1_ESCALATED_TO="ceo"`.
 

--- a/commands/start.md
+++ b/commands/start.md
@@ -67,7 +67,6 @@ Built-in defaults (also see `/gh-issue-driven:config show`):
   "gate1": {
     "primary": "/claude-c-suite:ask",
     "fallback": "/claude-c-suite:ceo",
-    "decline_tokens": ["DECLINE", "needs synthesis", "requires multiple lenses", "escalate"],
     "yellow_continue_requires_confirm": true
   }
 }
@@ -178,29 +177,44 @@ Capture the full skill output as `ASK_OUTPUT`.
 
 ### 10. Detect decline and escalate if needed
 
-Scan `ASK_OUTPUT` for any of the configured `gate1.decline_tokens` (case-insensitive substring match): `DECLINE`, `needs synthesis`, `requires multiple lenses`, `escalate`.
+Scan `ASK_OUTPUT` for a **structured decline verdict** — a line matching the regex
+`^\s*##\s*Verdict:\s*decline\b` (case-insensitive). If multiple match, the **last one wins**.
 
-- **If a decline token is present**: escalate.
+Free-form mentions of `decline`, `needs synthesis`, `escalate`, etc. inside the analysis body
+are **not** decline signals — they are the reviewer's reasoning. Only the structured verdict
+line counts. (This is the same contract used in step 11 for color verdicts; decline is just
+a 5th valid token on the same line, not a separate channel.)
+
+- **If a `## Verdict: decline` line is present**: escalate.
 
   > **Invoke the `/claude-c-suite:ceo` skill via the Skill tool**, passing the same gate1 prompt block plus a one-line note `(Escalated from /ask: <first 200 chars of ask output>)`. Wait for the full markdown response.
 
   Use the `/ceo` output as `GATE1_OUTPUT`. Set `GATE1_REVIEWER="ask"` and `GATE1_ESCALATED_TO="ceo"`.
 
-- **If no decline token is present**: use `ASK_OUTPUT` as `GATE1_OUTPUT`. Set `GATE1_REVIEWER="ask"` and `GATE1_ESCALATED_TO=null`.
+- **Otherwise**: use `ASK_OUTPUT` as `GATE1_OUTPUT`. Set `GATE1_REVIEWER="ask"` and `GATE1_ESCALATED_TO=null`.
 
 If the `/ask` skill is not installed, fall back directly to `/ceo`. If both are missing, log a loud warning `gate1 skipped: claude-c-suite not installed`, set `GATE1_VERDICT="unknown"`, and continue (do not abort).
 
 ### 11. Parse the gate1 verdict
 
-Look for an explicit verdict line in `GATE1_OUTPUT`, in this priority order:
+Parse `GATE1_VERDICT` from `GATE1_OUTPUT` using this two-step contract:
 
-1. A line matching `^##\s*Verdict:\s*(green|yellow|red)\b` (case-insensitive) — use that color.
-2. Otherwise, apply heuristics on the full text:
-   - **red** if any of: `BLOCKER`, `must fix before`, `red flag`, `do not proceed`, three or more `## Verdict: red`-style markers, three or more `Critical:` lines.
+1. **Structured verdict line (preferred, canonical)**: scan for **all** lines matching the regex
+   `^\s*##\s*Verdict:\s*(green|yellow|red)\b` (case-insensitive). If one or more match, take the
+   **LAST** occurrence (last-wins), lowercase the captured token, and use it. Trailing punctuation
+   on the line (e.g. `## Verdict: green.`) is fine — `\b<token>\b` already handles it. Token case
+   is normalized via `.lower()`, so `Green`, `green`, and `GREEN` all map to `green`.
+
+2. **Heuristic fallback** — only runs when **no structured line was found**. Emit a single warn-level
+   log line `verdict_parser=heuristic gate=gate1 reason=no_structured_line` so the soft-deprecation
+   of the heuristic can be tracked in real runs (this signal feeds the v0.4 decision to drop
+   heuristics entirely).
+   - **red** if any of: `BLOCKER`, `must fix before`, `red flag`, `do not proceed`, three or more `Critical:` lines.
    - **yellow** if any of: `WARN`, `consider`, `recommend`, one or two `Warning:` markers, no red signals.
    - **green** otherwise.
 
-Set `GATE1_VERDICT` accordingly.
+Set `GATE1_VERDICT` accordingly. Note: `decline` is handled in step 10 and never reaches step 11 —
+by the time `GATE1_OUTPUT` is set here, decline has already been escalated to `/ceo`.
 
 ### 12. Verdict handling
 

--- a/commands/start.md
+++ b/commands/start.md
@@ -210,7 +210,7 @@ reflection `## Verdict: green`" correctly resolves to green and does NOT escalat
 - **Otherwise** (the last token is `green`/`yellow`/`red`, OR no structured line was found at all):
   use `ASK_OUTPUT` as `GATE1_OUTPUT`. Set `GATE1_REVIEWER="ask"` and `GATE1_ESCALATED_TO=null`.
   The verdict will be parsed in step 11 (which re-scans the same lines using the same last-wins
-  contract — duplication is intentional for v0.1.1; #14 / future refactor will share the parser).
+  contract — duplication is intentional for v0.1.1; a future refactor will share the parser).
 
 If the `/ask` skill is not installed, fall back directly to `/ceo`. If both are missing, log a loud warning `gate1 skipped: claude-c-suite not installed`, set `GATE1_VERDICT="unknown"`, and continue (do not abort).
 


### PR DESCRIPTION
Closes #1

## Summary
- Replace the substring `decline` matcher in gate1 (`commands/start.md` step 10) with a structured `## Verdict: decline` line — last-wins, case-insensitive. Free-form mentions of "decline" inside the analysis body are no longer routing signals.
- Formalize the structured-line-first contract for all verdict parsing (gate1 colors, gate2 audit pass/fail, gate2 advisor colors) with explicit rules: last-wins, case-normalized via `.lower()`, trailing punctuation tolerated. Heuristic fallback only runs when no structured line is present and emits a `verdict_parser=heuristic` warn log so soft-deprecation can be tracked toward the v0.4 removal decision.
- Drop the `decline_tokens` config key from `commands/config.md` and `commands/start.md` defaults. The contract is now hard-coded as `## Verdict: decline` (5th value of the same `## Verdict:` line) — no separate channel, no config knob.
- Document the verdict line convention in `README.md` and `README.ja.md` with the 5 explicit rules and the full set of 6 valid token values, separated by which gate consumes them.

## Implementation notes
- gate2 advisors do not support `decline` — that's a gate1 routing concept only. ship.md step 8 now states this explicitly to prevent future confusion.
- The parser logic is currently inline in three places (`start.md` step 11, `ship.md` step 7, `ship.md` step 8) with subtle variations. CTO flagged this as pre-existing duplication worth extracting in v0.2.0+; not in scope for this hotfix.
- The diff is intentionally docs/contract-only — no Python or shell helper introduced. The contract lives in the command markdown bodies that drive the orchestrator.

## Pre-PR review summary
- audit: **pass** (hard gate cleared — no conformance violations; CI lint untouched)
- cso: green (no new attack surface; the structured-vs-heuristic trade-off is internal to trusted reviewer skills, and the issue-body sanitization that closes the prompt-injection path is filed as #5)
- qa-lead: **yellow** — lands without the fixtures from #3. CAIO already flagged this sequencing concern at gate1. **Known and accepted; #3 is the immediate follow-up branch.**
- cto: green (net tech-debt reduction; well-instrumented soft-deprecation; pre-existing duplication noted but not introduced here)
- cmo (added per dogfooding instruction because the diff includes README): **yellow** — soft-deprecation language slightly leaks implementation detail into the public README, and the alpha banner from #4 isn't there yet. **Known and accepted; #4 is the second follow-up.**
- gate1: **green** via `/claude-c-suite:ask` (routed to CAIO lens, no escalation to /ceo)

The yellow aggregate (qa-lead, cmo) was explicitly accepted on the second `/gh-issue-driven:ship` invocation. Both yellows convert to green once #3 (fixtures) and #4 (alpha banner) land, both already filed.

## Dogfooding findings caught during this run
This was the first end-to-end use of `/gh-issue-driven:start` + `/ship` against the plugin's own repo. Three bugs in start.md were caught and filed as separate issues:

1. **#11** — `start.md` step 5 references a non-existent `repository` field on `gh issue view --json`. Worked around manually.
2. **#12** — `memory.context_id` default `"kagura-dev"` is a name, but `mcp__kagura-memory__recall` requires a UUID. Fix: resolve name → UUID via `list_contexts` at runtime.
3. **#1 (this PR)** — the substring `decline` matcher in step 10 would have falsely escalated this very gate1, because the CAIO review *quoted* the word "decline" multiple times. This PR fixes exactly that bug. The plugin caught its own bug on its first dogfooding run, on the exact issue dedicated to fixing that bug.

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/1-feat-verdict-parser-replace-heuristic-with-st.gate1.md
- ~/.claude/cache/gh-issue-driven/1-feat-verdict-parser-replace-heuristic-with-st.gate2.md

🤖 Generated via /gh-issue-driven:ship
