### PR TITLE
fix(start.md): drop non-existent `repository` field from gh issue view --json (#11)

### DIFF
--- a/commands/start.md
+++ b/commands/start.md
@@ -33,6 +33,7 @@ You are starting work on a GitHub issue. Read each step carefully — the order 
   - Bare number `142` → use current repo (resolve via `gh repo view --json nameWithOwner -q .nameWithOwner`)
   - URL form `https://github.com/foo/bar/issues/142` → parse owner, repo, number
   - Short form `foo/bar#142` → parse the same way
+- Set `REPO_FULL_NAME` from the normalized `<owner/repo>`. This is the canonical binding point for the variable; downstream steps (state file, recap) read it from here.
 - Set booleans from remaining tokens:
   - `DRY_RUN=true` if `dry-run` is present
   - `FORCE=true` if `force` is present
@@ -100,10 +101,10 @@ Unless `NO_MEMORY` is set:
 
 ```bash
 gh issue view <issue_number> --repo <owner/repo> \
-  --json number,title,body,url,labels,author,repository
+  --json number,title,body,url,labels,author
 ```
 
-Parse the returned JSON into local variables: `ISSUE_NUM`, `ISSUE_TITLE`, `ISSUE_BODY`, `ISSUE_URL`, `ISSUE_LABELS` (array of label names), `ISSUE_AUTHOR`, `REPO_FULL_NAME`.
+Parse the returned JSON into local variables: `ISSUE_NUM`, `ISSUE_TITLE`, `ISSUE_BODY`, `ISSUE_URL`, `ISSUE_LABELS` (array of label names), `ISSUE_AUTHOR`. (`REPO_FULL_NAME` is already bound in step 1 — `repository` is **not** a valid `gh issue view --json` field.)
 
 If the API returns a 404, abort with `issue #<num> not found in <repo>`.
 


### PR DESCRIPTION
Closes #11

## Summary

- `gh issue view --json` rejects `repository` (it isn't a valid field), so `/gh-issue-driven:start` exited non-zero at step 5 on every run. Caught during dogfooding of `/gh-issue-driven:start 1` on 2026-04-09.
- Drops `,repository` from the `--json` field list and removes `REPO_FULL_NAME` from step 5's parse list.
- Rebinds `REPO_FULL_NAME` at its **canonical source in step 1**, with an explicit bullet so the dependency chain is documented (gate1 reviewer recommendation, folded into the implementation).
- Inline parenthetical added to step 5 explaining *why* `repository` is gone — defends the future reader from re-introducing it.

## Implementation notes

- 1 file changed, +3/-2 lines (`commands/start.md`).
- Verified mid-session by running the corrected `gh issue view --json number,title,body,url,labels,author` form against issue #11 itself; returned 200 with all required fields.
- Frontmatter unchanged; lint contract preserved (`.github/workflows/lint.yml` checks pass locally).
- No version bump (v0.1.1 will be a separate chore commit once all v0.1.1 milestone hotfixes land).
- Regression test correctly deferred to #3 (ships the test framework for these contracts).

## Pre-PR review summary

- gate1: green via `/claude-c-suite:ask` (single-lens routed to QA Lead, no escalation)
- gate2:
  - audit: pass (executed against this repo's actual lint contract — JSON syntax + version/name sync + frontmatter parser — since `/claude-c-suite:audit`'s default `scripts/audit.py` is a different plugin's self-audit script)
  - cso: green
  - qa-lead: green
  - cto: green

Full reviews are saved in the plugin cache:
- `~/.claude/cache/gh-issue-driven/11-fix-start-md-step-5-drop-non-existent-reposi.gate1.md`
- `~/.claude/cache/gh-issue-driven/11-fix-start-md-step-5-drop-non-existent-reposi.gate2.md`

🤖 Generated via /gh-issue-driven:ship