### PR TITLE
fix: detect Copilot reviewer queue state, prompt Mode A in doctor (#15)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -45,3 +45,6 @@ jobs:
 
       - name: Verify command frontmatter parses and has required fields
         run: python3 .github/workflows/check-frontmatter.py
+
+      - name: Run copilot-detection fixture tests
+        run: bash tests/copilot-detection.sh

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -48,3 +48,6 @@ jobs:
 
       - name: Run copilot-detection fixture tests
         run: bash tests/copilot-detection.sh
+
+      - name: Verify ship.md inline jq stays in sync with canonical filter
+        run: bash tests/jq-sync-check.sh

--- a/README.ja.md
+++ b/README.ja.md
@@ -15,16 +15,24 @@
 ## 60秒クイックスタート
 
 ```text
+# ステップ0 — リポジトリの GitHub Settings ページで一度だけ:
+#   Settings → Code review → ☑ Automatic Copilot code review
+#   URL: https://github.com/<owner>/<repo>/settings/code-review
+#   これを有効にすると、Copilot レビューループが gh CLI のバージョンに依存せず動く。
+#   有効化しない場合は gh CLI >= 2.88.0 が必要 (下記「必要なバージョン」参照)。
+
 # Claude Code セッション内:
 /plugin marketplace add JFK/gh-issue-driven
 /plugin install gh-issue-driven
 
 # 任意のリポジトリで:
-/gh-issue-driven:doctor          # 初回環境チェック
+/gh-issue-driven:doctor          # 初回環境チェック (ステップ0 の確認 prompt も走る)
 /gh-issue-driven:start 142       # フェーズ1
 # ... 実装 ...
 /gh-issue-driven:ship            # フェーズ2
 ```
+
+> **ステップ0 が必要な理由**: GitHub の "Automatic Copilot code review" リポジトリ設定を有効にすると、PR 作成時と push のたびに Copilot レビューが自動で要求されるため、gh CLI のバージョンに関係なくループが自走します。有効化していない場合、プラグインは `gh pr edit --add-reviewer @copilot` にフォールバックしますが、これは `gh < 2.88.0` で **silent に no-op します** ([#15](https://github.com/JFK/gh-issue-driven/issues/15) 参照)。`/gh-issue-driven:doctor` は repo ごとに7日間隔でステップ0 の確認 prompt を出し、どちらのモードも使えない場合は hard fail します。
 
 ---
 
@@ -109,10 +117,22 @@ gh pr edit <num> --add-reviewer @copilot
 
 ループは **never-blocking**：5周使い切っても PR は開いたまま、残りは手動で対応してもらいます。
 
-### 必要なバージョン
+### 必要なバージョン (どちらか一方)
 
-- `gh` CLI v2.88.0 以降（Copilot reviewer サポート、[2026年3月の Changelog](https://github.blog/changelog/2026-03-11-request-copilot-code-review-from-github-cli/)）
-- リポジトリで GitHub Copilot code review が有効化されていること
+Copilot ループには **2つの動作モード**があり、**どちらか一方**が成立していればループが end-to-end で動きます：
+
+- **Mode A (推奨)** — リポジトリ設定で `Settings → Code review → ☑ Automatic Copilot code review` を有効化。**任意の `gh` CLI バージョンで動く**。Copilot が PR 作成時と push のたびに自動で要求される。
+- **Mode B** — `gh` CLI **v2.88.0 以降** ([2026年3月の Changelog](https://github.blog/changelog/2026-03-11-request-copilot-code-review-from-github-cli/) で追加された本物の `--add-reviewer @copilot` サポート)。それ以前の `gh` バージョンでは手動 reviewer add が silent に no-op する ([#15](https://github.com/JFK/gh-issue-driven/issues/15) 参照)。
+
+両モード共通: リポジトリのプランで GitHub Copilot code review 機能が利用可能であること。
+
+### Web UI による手動フォールバック
+
+Mode A を有効化できず、`gh` も 2.88.0+ にアップグレードできない場合：
+
+1. プラグインが PR を作成した後、GitHub Web UI で PR を開く。
+2. 右サイドバー → Reviewers → "Copilot" をクリック。
+3. Copilot のレビューが届いたら `/gh-issue-driven:ship` を再実行する。(resume mode は [#14](https://github.com/JFK/gh-issue-driven/issues/14) で追跡中。)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -15,16 +15,24 @@ The whole flow is bracketed by `kagura-memory` `session-start` and `session-summ
 ## 60-second quickstart
 
 ```text
+# Step 0 — one-time, in your repo's GitHub Settings page:
+#   Settings → Code review → ☑ Automatic Copilot code review
+#   URL: https://github.com/<owner>/<repo>/settings/code-review
+#   This makes the Copilot review loop work on any gh CLI version.
+#   Without it, you need gh CLI >= 2.88.0 (see Requirements below).
+
 # In any Claude Code session:
 /plugin marketplace add JFK/gh-issue-driven
 /plugin install gh-issue-driven
 
 # In a repo:
-/gh-issue-driven:doctor          # one-time environment check
+/gh-issue-driven:doctor          # one-time environment check (will prompt to confirm Step 0)
 /gh-issue-driven:start 142       # phase 1
 # ... implement ...
 /gh-issue-driven:ship            # phase 2
 ```
+
+> **Why Step 0 matters**: GitHub's "Automatic Copilot code review" repo setting auto-requests Copilot's review on every PR open and every push, making the loop self-sustaining on any `gh` version. Without it, the plugin falls back to `gh pr edit --add-reviewer @copilot`, which **silently no-ops** on `gh < 2.88.0` (see [#15](https://github.com/JFK/gh-issue-driven/issues/15)). `/gh-issue-driven:doctor` will prompt you to confirm Step 0 once per 7 days per repo and hard-fail if neither path is available.
 
 ---
 
@@ -109,10 +117,22 @@ Then loops up to **5 iterations** (configurable):
 
 The loop is **never blocking**: if it exhausts 5 iterations, the PR stays open and you handle remaining feedback manually.
 
-### Requirements
+### Requirements (one of)
 
-- `gh` CLI v2.88.0 or later (Copilot reviewer support, [March 2026 changelog](https://github.blog/changelog/2026-03-11-request-copilot-code-review-from-github-cli/)).
-- The repo must have GitHub Copilot code review enabled.
+The Copilot loop has **two operational modes**. **One must be true** for the loop to function end-to-end:
+
+- **Mode A (recommended)** — `Settings → Code review → ☑ Automatic Copilot code review` enabled at the repo level. Works on any `gh` CLI version. Copilot is auto-requested on every PR open and on every push.
+- **Mode B** — `gh` CLI **v2.88.0 or later** (the version that added real `--add-reviewer @copilot` support per the [March 2026 changelog](https://github.blog/changelog/2026-03-11-request-copilot-code-review-from-github-cli/)). Earlier `gh` versions silently no-op the manual reviewer add — see [#15](https://github.com/JFK/gh-issue-driven/issues/15).
+
+Both also require: the repo must have GitHub Copilot code review feature available on its plan.
+
+### Manual Web UI fallback
+
+If you can't enable Mode A AND can't upgrade `gh` to 2.88.0+:
+
+1. After the plugin creates the PR, open it in the GitHub Web UI.
+2. In the right sidebar → Reviewers → click "Copilot".
+3. Re-run `/gh-issue-driven:ship` once Copilot's review lands. (Resume mode is tracked as [#14](https://github.com/JFK/gh-issue-driven/issues/14).)
 
 ---
 

--- a/commands/config.md
+++ b/commands/config.md
@@ -56,7 +56,9 @@ This command is **mostly read-only**. The single mutating action is `init`, whic
     "poll_interval_sec": 60,
     "max_wait_sec": 900,
     "run_tests_after_edits": true,
-    "reply_to_non_actionable": false
+    "reply_to_non_actionable": false,
+    "verification_wait_sec": 30,
+    "skip_setup_prompt": false
   },
   "pr": {
     "draft_default": false,

--- a/commands/doctor.md
+++ b/commands/doctor.md
@@ -1,5 +1,5 @@
 ---
-description: Diagnose the gh-issue-driven environment — verifies gh CLI auth, required plugins, git repo, configuration, and cache directory. Read-only.
+description: Diagnose the gh-issue-driven environment — verifies gh CLI auth, required plugins, git repo, configuration, and cache directory. Mostly read-only; the only mutation is the bounded Copilot setup confirmation cache (see Trust boundary).
 arguments:
   - name: input
     description: "Optional: 'verbose' for full output, 'fix' to print 'try this' hints next to failures (never auto-remediates)."
@@ -8,9 +8,11 @@ arguments:
 
 ## Trust boundary
 
-This command is **mostly read-only**. It must not modify any file outside its **single permitted target**:
+This command is **mostly read-only**. It must not modify any file outside its **single permitted file target**:
 
-- `~/.claude/cache/gh-issue-driven/<repo-flat>.copilot-setup.json` — the bounded confirmation cache for the "Copilot review setup" check below. Permitted actions on this single file: **create, refresh (atomic temp + mv), and delete** — and nothing else. The check uses the AskUserQuestion tool to confirm Mode A status; on "Yes" it refreshes the cache, on "No, Mode B" it deletes the cache, on "Skip" it does neither. No other section of doctor writes anywhere.
+- `~/.claude/cache/gh-issue-driven/<repo-flat>.copilot-setup.json` — the bounded confirmation cache for the "Copilot review setup" check below. Permitted actions on this single file: **create, refresh (atomic temp + mv), and delete** — and nothing else. The check uses the AskUserQuestion tool to confirm Mode A status; on "Yes" it refreshes the cache, on "No, Mode B" it deletes the cache, on "Skip" it does neither. No other section of doctor writes file content anywhere.
+
+The single permitted file target requires its parent directory `~/.claude/cache/gh-issue-driven/` to exist. doctor may **create that parent directory** via `mkdir -p` as a precondition for the permitted file actions. The cache directory writable check at step 6 below is the canonical place where this `mkdir -p` runs. No other directory creation is permitted anywhere in doctor.
 
 It must not install anything, change git state, or call any non-read-only tool. Print only `set` / `unset` for token-shaped environment variables — never echo their values.
 
@@ -81,7 +83,9 @@ The 7-day TTL is a fixed const in this command, not a config knob — re-confirm
 
 #### Check logic
 
-Read `copilot.skip_setup_prompt` from config. If true, print one line `✅ Copilot setup: prompt skipped (copilot.skip_setup_prompt=true)` and skip to the gh version check at the bottom of this section.
+Load the effective configuration just-in-time for this section: read `~/.claude/gh-issue-driven-config.json` if it exists and parses cleanly, then deep-merge user values over the built-in defaults documented in `/gh-issue-driven:config`. If the file is absent or unparseable, use the defaults silently — the broader Configuration file health check at step 11 (informational) will surface the parse error separately. The just-in-time load is necessary because this Copilot setup section runs in the Required-checks zone, **before** step 11; the two reads do not conflict because step 11 is informational and never blocks.
+
+From the merged config, read `copilot.skip_setup_prompt` (default `false`). If true, print one line `✅ Copilot setup: prompt skipped (copilot.skip_setup_prompt=true)` and skip to the gh version check at the bottom of this section.
 
 Otherwise:
 
@@ -175,7 +179,7 @@ Otherwise:
    ```
    Warn if empty.
 
-6. **Cache directory writable**
+6. **Cache directory writable** — this is the canonical place where the trust-boundary-permitted `mkdir -p` runs. The cache directory is intrinsic to gh-issue-driven (it holds state files, gate1/gate2 markdowns, and the Copilot setup confirmation cache from the section above), so doctor creates it on first run rather than requiring the user to set it up manually.
    ```bash
    mkdir -p ~/.claude/cache/gh-issue-driven && test -w ~/.claude/cache/gh-issue-driven
    ```
@@ -249,4 +253,4 @@ If `verbose` flag is set, also dump the effective configuration (deep-merged use
 
 ---
 
-> ⚠️ **Read-only diagnostic**: This command never modifies anything. The `fix` flag only adds suggested commands to the output — you must run them yourself.
+> ⚠️ **Mostly read-only diagnostic**: doctor's only mutations are (a) the bounded Copilot setup confirmation cache file declared in the Trust boundary at the top of this command, and (b) `mkdir -p ~/.claude/cache/gh-issue-driven` as a precondition for that cache file (also covered by the Trust boundary). It never installs anything, never touches git state, never edits source files, and never writes outside the plugin's own cache directory. The `fix` flag only adds suggested commands to the output — you must run them yourself.

--- a/commands/doctor.md
+++ b/commands/doctor.md
@@ -129,11 +129,28 @@ Otherwise:
      - **"No, Mode B (gh CLI)"** → delete the cache file (so the next run re-prompts). Fall through to the gh version check, which will hard-fail if `gh < 2.88.0`.
      - **"Skip"** → do not refresh, do not delete. Print a hint that setting `copilot.skip_setup_prompt=true` will silence this prompt permanently. Continue to the gh version check.
 
-3. **gh CLI version check** (always runs after the cache logic resolves). Use the same comparison idiom as `commands/ship.md` step 1's pre-flight to keep the two warn-paths in lockstep:
+3. **gh CLI version check** (always runs after the cache logic resolves). Use the same portable POSIX-awk compare as `commands/ship.md` step 1's pre-flight to keep the two paths in lockstep:
 
    ```bash
-   GH_VER=$(gh --version 2>/dev/null | awk 'NR==1 {print $3}')
-   if printf '%s\n%s\n' '2.88.0' "$GH_VER" | sort -V -C 2>/dev/null; then
+   # Strip a leading "v" so a future "gh version v2.88.0" output still parses cleanly.
+   GH_VER=$(gh --version 2>/dev/null | awk 'NR==1 {sub(/^v/,"",$3); print $3}')
+   # Portable POSIX awk version compare. `sort -V -C` is GNU-only and silently
+   # breaks on macOS/BSD (it would mark every version as "older", which would
+   # FALSELY trip the hard-fail "neither mode is available" path below for
+   # macOS users on perfectly good gh CLI versions). awk's numeric coercion is
+   # POSIX-mandatory and works identically on macOS, Linux, BSD, WSL.
+   if [ -n "$GH_VER" ] && awk -v ver="$GH_VER" 'BEGIN {
+     sub(/^v/, "", ver);
+     split(ver, v, ".");
+     # exit 0 = OK (>= 2.88.0), exit 1 = too old.
+     # NOTE: this is OPPOSITE polarity to ship.md step 1 (which uses
+     # awk-true=older because ship.md emits a warning while doctor.md
+     # sets a positive flag). Same idiom, different sense.
+     if ((v[1]+0) > 2)  exit 0     # major > 2 → newer → OK
+     if ((v[1]+0) < 2)  exit 1     # major < 2 → older → not OK
+     if ((v[2]+0) >= 88) exit 0    # major == 2, minor >= 88 → OK
+     exit 1                        # major == 2, minor < 88 → not OK
+   }'; then
      GH_VER_OK=true
    else
      GH_VER_OK=false

--- a/commands/doctor.md
+++ b/commands/doctor.md
@@ -8,7 +8,11 @@ arguments:
 
 ## Trust boundary
 
-This command is **read-only**. It must not modify any file, install anything, change git state, or call any non-read-only tool. Print only `set` / `unset` for token-shaped environment variables — never echo their values.
+This command is **mostly read-only**. It must not modify any file outside its **single permitted target**:
+
+- `~/.claude/cache/gh-issue-driven/<repo-flat>.copilot-setup.json` — the bounded confirmation cache for the "Copilot review setup" check below. Permitted actions on this single file: **create, refresh (atomic temp + mv), and delete** — and nothing else. The check uses the AskUserQuestion tool to confirm Mode A status; on "Yes" it refreshes the cache, on "No, Mode B" it deletes the cache, on "Skip" it does neither. No other section of doctor writes anywhere.
+
+It must not install anything, change git state, or call any non-read-only tool. Print only `set` / `unset` for token-shaped environment variables — never echo their values.
 
 ## Steps
 
@@ -47,6 +51,104 @@ Group checks under three headings: **Required**, **Recommended**, **Informationa
    - `git`, `gh`, `jq` must all be on PATH.
    - `python3` is recommended (used by some helper checks).
    For each missing one print a `❌` and `try: apt install <pkg>` / `brew install <pkg>` hint when `fix` is set.
+
+### Copilot review setup (interactive — runs before the rest of the recommended checks)
+
+The Copilot review loop in `/gh-issue-driven:ship` works in two modes. **One must be true** for the loop to function end-to-end:
+
+- **Mode A — Automatic Copilot code review (recommended)**: a per-repo setting at `https://github.com/<owner>/<repo>/settings/code-review`. When enabled, GitHub auto-requests Copilot's review on PR open AND on every push to the PR. The plugin's `--add-reviewer` call becomes redundant (in the good sense). **Works on any `gh` CLI version.**
+- **Mode B — Manual via `gh pr edit --add-reviewer @copilot`**: requires `gh` CLI **>= 2.88.0** (the version that added real Copilot reviewer support per the March 2026 changelog). Earlier `gh` versions silently no-op (exit 0, no error, but the API server-side never queues Copilot — see issue #15).
+
+The plugin **cannot** query Mode A's status via REST or GraphQL (verified 2026-04-09: `GET /repos/{o}/{r}` has no field, `code-review-settings` returns 404, `repository` GraphQL type lacks the field). So this check uses a **bounded confirmation cache** instead of an API probe:
+
+#### How the cache works
+
+Cache file: `~/.claude/cache/gh-issue-driven/<repo-flat>.copilot-setup.json` where `<repo-flat>` is `<owner>-<repo>` (slash → dash, lowercased).
+
+Schema:
+
+```json
+{
+  "schema_version": 1,
+  "repo": "<owner>/<repo>",
+  "mode_a_confirmed": true,
+  "confirmed_at": "<UTC ISO-8601>",
+  "expires_at": "<UTC ISO-8601, confirmed_at + 7 days>"
+}
+```
+
+The 7-day TTL is a fixed const in this command, not a config knob — re-confirming repo settings every 1-day vs 14-day is not a meaningful user preference, and adding a config key would just expand the surface for nobody. To force a re-prompt, delete the cache file directly.
+
+#### Check logic
+
+Read `copilot.skip_setup_prompt` from config. If true, print one line `✅ Copilot setup: prompt skipped (copilot.skip_setup_prompt=true)` and skip to the gh version check at the bottom of this section.
+
+Otherwise:
+
+1. Compute `<repo-flat>` from `gh repo view --json nameWithOwner -q .nameWithOwner` (slash → dash, lowercased).
+2. Resolve the cache state into one of two paths:
+
+   **Path A — Cache present and fresh** (cache file exists AND current UTC < `expires_at`):
+   - Print one line and skip the prompt:
+     ```
+     ✅ Copilot setup: Mode A confirmed <confirmed_at> (re-check on <expires_at>)
+     ```
+   - Continue to the gh version check.
+
+   **Path B — Needs prompt** (cache absent OR cache expired):
+   - On expired only, print a one-line preamble:
+     ```
+     ⚠️  Copilot setup: previous Mode A confirmation expired on <expires_at>
+     ```
+   - On absent (first run for this repo), print the **full** Copilot setup explanation block:
+     ```
+     ### Copilot code review setup
+
+     The Copilot review loop in /gh-issue-driven:ship works in two modes. ONE must be enabled:
+
+       Mode A — Automatic (recommended)
+         Repo setting: https://github.com/<owner>/<repo>/settings/code-review
+         Toggle: ☑ Automatic Copilot code review
+         Result: Copilot reviews every PR automatically on create AND on every push.
+         Works on any gh CLI version. No manual reviewer add ever needed.
+
+       Mode B — Manual via gh pr edit --add-reviewer @copilot
+         Requires: gh CLI >= 2.88.0
+         Earlier gh versions silently no-op (issue #15).
+     ```
+   - On expired (cache existed), skip the long block and print only:
+     ```
+     Is "Automatic Copilot code review" still enabled at:
+       https://github.com/<owner>/<repo>/settings/code-review
+     ```
+   - In both expired and absent sub-cases, then use the **AskUserQuestion tool** with the same question and options:
+     - Question: "Mode A still enabled?"
+     - Options: `["Yes", "No, Mode B (gh CLI)", "Skip — set copilot.skip_setup_prompt=true in config to silence"]`
+   - Handle the answer (identical for both sub-cases):
+     - **"Yes"** → refresh the cache (atomic temp + mv) with `confirmed_at=now`, `expires_at=now + 7 days`. Continue to the gh version check.
+     - **"No, Mode B (gh CLI)"** → delete the cache file (so the next run re-prompts). Fall through to the gh version check, which will hard-fail if `gh < 2.88.0`.
+     - **"Skip"** → do not refresh, do not delete. Print a hint that setting `copilot.skip_setup_prompt=true` will silence this prompt permanently. Continue to the gh version check.
+
+3. **gh CLI version check** (always runs after the cache logic resolves). Use the same comparison idiom as `commands/ship.md` step 1's pre-flight to keep the two warn-paths in lockstep:
+
+   ```bash
+   GH_VER=$(gh --version 2>/dev/null | awk 'NR==1 {print $3}')
+   if printf '%s\n%s\n' '2.88.0' "$GH_VER" | sort -V -C 2>/dev/null; then
+     GH_VER_OK=true
+   else
+     GH_VER_OK=false
+   fi
+   ```
+
+   Three outcomes:
+
+   - `GH_VER_OK=true` → print `✅ gh CLI: $GH_VER (Mode B available)`.
+   - `GH_VER_OK=false` AND **Path A** (Mode A confirmed) → print `⚠️  gh CLI: $GH_VER (older than 2.88.0; Mode B unavailable but Mode A is confirmed, so loop will work)`.
+   - `GH_VER_OK=false` AND NOT Path A (Mode A unconfirmed / declined / cache absent) → print `❌ gh CLI: $GH_VER (older than 2.88.0; neither mode is available — the Copilot loop will silently skip)`. **This is the only hard error in the Copilot setup section.** Append a `try:` line if `fix` flag is set:
+     ```
+        try: enable Mode A at https://github.com/<owner>/<repo>/settings/code-review
+             OR upgrade gh: https://cli.github.com/
+     ```
 
 ### Recommended checks
 

--- a/commands/ship.md
+++ b/commands/ship.md
@@ -36,16 +36,16 @@ if [ "$BRANCH" = "$DEFAULT_BRANCH" ]; then
 fi
 ```
 
-#### gh CLI version check (warn-only)
+#### gh CLI version check (warn-only, runs unconditionally)
 
-If `copilot.enabled` is true (default), check `gh --version` against the 2.88.0 floor (the version that added real `--add-reviewer @copilot` support per the March 2026 changelog). On older versions the manual reviewer add will silently no-op — the loop still works if the repo has **Automatic Copilot code review** enabled (see `/gh-issue-driven:doctor`), but operators on older `gh` without auto-review will see the loop skip.
+This check runs as part of pre-flight, before configuration is loaded — so it cannot read `copilot.enabled` and intentionally always runs. It compares `gh --version` against the 2.88.0 floor (the version that added real `--add-reviewer @copilot` support per the March 2026 changelog). On older versions the manual reviewer add will silently no-op. The warning is **harmless when copilot is disabled** (the loop won't run anyway), so emitting it unconditionally is the simpler design vs deferring to step 2.
 
 ```bash
 GH_VER=$(gh --version 2>/dev/null | awk 'NR==1 {print $3}')
 if [ -n "$GH_VER" ]; then
   if ! printf '%s\n%s\n' '2.88.0' "$GH_VER" | sort -V -C; then
     echo "warning: gh CLI $GH_VER is older than 2.88.0 — manual Copilot reviewer add will silently no-op."
-    echo "         The loop will still work IF this repo has Automatic Copilot code review enabled."
+    echo "         If copilot is enabled, the loop will still work IF this repo has Automatic Copilot code review enabled."
     echo "         Run /gh-issue-driven:doctor to confirm setup, or upgrade gh: https://cli.github.com/"
   fi
 fi
@@ -310,7 +310,7 @@ if [ "$COPILOT_QUEUED" = "false" ]; then
 fi
 ```
 
-> **JQ filter sync**: the unified `jq -r` expression above (between `# JQ_DETECT_FILTER_BEGIN` and `# JQ_DETECT_FILTER_END` sentinels) is the body of the `detect` function in `tests/copilot-detection.jq`. They are intentionally byte-equivalent. CI enforces this: `tests/jq-sync-check.sh` extracts the inline filter via the sentinels, runs both filters against every fixture, and asserts identical output. When you change one, update the other in the same commit — CI will fail loud otherwise.
+> **JQ filter sync**: the unified `jq -r` expression above (between `# JQ_DETECT_FILTER_BEGIN` and `# JQ_DETECT_FILTER_END` sentinels) is **semantically equivalent** to the body of the `detect` function in `tests/copilot-detection.jq` — meaning both produce identical output across every fixture in `tests/fixtures/copilot-detection/`. They are NOT byte-identical: the inline form uses `any(test(...))` (predicate form) while the canonical form uses `map(test(...)) | any` (mapped form). These are equivalent in jq but not source-identical. CI enforces the semantic equivalence: `tests/jq-sync-check.sh` extracts the inline filter via the sentinels, runs both filters against every fixture, and asserts identical output strings. When you change one, update the other in the same commit — CI will fail loud otherwise.
 
 If `COPILOT_QUEUED` is `false`:
 - Skip step 14 entirely (the polling loop has nothing to wait for).

--- a/commands/ship.md
+++ b/commands/ship.md
@@ -282,8 +282,12 @@ VERIFY_WAIT_SEC="<from config copilot.verification_wait_sec, default 30>"
 gh pr edit "$PR_NUMBER" --add-reviewer "$REVIEWER_LOGIN" >/dev/null 2>&1 || true
 
 # Bounded poll for either signal. Polls every 2s up to VERIFY_WAIT_SEC (default 30s).
-# Mode A's auto-review typically lands within 1-3s of PR creation, so a tight poll
-# interval makes the common case ~3x faster than the original 5s spacing.
+# Mode A auto-review latency varies widely in practice (observed 1s to 240s+ depending
+# on Copilot infra load and repo settings). The 2s poll interval keeps the fast-fire
+# case fast without adding meaningful cost to the slow case. The 30s ceiling is the
+# real timing default — and it is wrong for slow-Mode-A repos. See issue #23 for the
+# architectural fix that retires step 13's bounded wait entirely and lets step 14's
+# polling loop detect silent_no_op naturally.
 DEADLINE=$(( $(date +%s) + VERIFY_WAIT_SEC ))
 COPILOT_QUEUED=false
 DETECTION_METHOD="neither"

--- a/commands/ship.md
+++ b/commands/ship.md
@@ -299,6 +299,10 @@ gh pr edit "$PR_NUMBER" --add-reviewer "$REVIEWER_LOGIN" >/dev/null 2>&1 || true
 # real timing default — and it is wrong for slow-Mode-A repos. See issue #23 for the
 # architectural fix that retires step 13's bounded wait entirely and lets step 14's
 # polling loop detect silent_no_op naturally.
+#
+# TODO(#23): this whole DEADLINE/while/break block is the false-positive surface.
+# When #23 lands, replace it with a single fire-and-forget gh pr edit and rely on
+# step 14's polling loop to detect silent_no_op via "no Copilot activity after N polls".
 DEADLINE=$(( $(date +%s) + VERIFY_WAIT_SEC ))
 COPILOT_QUEUED=false
 DETECTION_METHOD="neither"

--- a/commands/ship.md
+++ b/commands/ship.md
@@ -290,9 +290,11 @@ DETECTION_METHOD="neither"
 while [ "$(date +%s)" -lt "$DEADLINE" ]; do
   DETECTION_METHOD=$(gh pr view "$PR_NUMBER" --json reviewRequests,latestReviews 2>/dev/null \
     | jq -r '
+        # JQ_DETECT_FILTER_BEGIN
         if   ((.reviewRequests // []) | map(.login // .name // "") | any(test("[Cc]opilot"))) then "requested_reviewers"
         elif ((.latestReviews  // []) | map(.author.login // "")   | any(test("[Cc]opilot"))) then "latest_reviews"
         else "neither" end
+        # JQ_DETECT_FILTER_END
       ' 2>/dev/null || echo "neither")
   if [ "$DETECTION_METHOD" != "neither" ]; then
     COPILOT_QUEUED=true
@@ -308,7 +310,7 @@ if [ "$COPILOT_QUEUED" = "false" ]; then
 fi
 ```
 
-> **JQ filter sync**: the unified `jq -r` expression above is the body of the `detect` function in `tests/copilot-detection.jq` (which the fixture-driven test in `tests/copilot-detection.sh` uses as canonical). They are intentionally byte-equivalent. When you change the detection logic, update **both** in the same commit. CI does not currently diff them — that's tracked as a follow-up.
+> **JQ filter sync**: the unified `jq -r` expression above (between `# JQ_DETECT_FILTER_BEGIN` and `# JQ_DETECT_FILTER_END` sentinels) is the body of the `detect` function in `tests/copilot-detection.jq`. They are intentionally byte-equivalent. CI enforces this: `tests/jq-sync-check.sh` extracts the inline filter via the sentinels, runs both filters against every fixture, and asserts identical output. When you change one, update the other in the same commit — CI will fail loud otherwise.
 
 If `COPILOT_QUEUED` is `false`:
 - Skip step 14 entirely (the polling loop has nothing to wait for).

--- a/commands/ship.md
+++ b/commands/ship.md
@@ -41,13 +41,24 @@ fi
 This check runs as part of pre-flight, before configuration is loaded — so it cannot read `copilot.enabled` and intentionally always runs. It compares `gh --version` against the 2.88.0 floor (the version that added real `--add-reviewer @copilot` support per the March 2026 changelog). On older versions the manual reviewer add will silently no-op. The warning is **harmless when copilot is disabled** (the loop won't run anyway), so emitting it unconditionally is the simpler design vs deferring to step 2.
 
 ```bash
-GH_VER=$(gh --version 2>/dev/null | awk 'NR==1 {print $3}')
-if [ -n "$GH_VER" ]; then
-  if ! printf '%s\n%s\n' '2.88.0' "$GH_VER" | sort -V -C; then
-    echo "warning: gh CLI $GH_VER is older than 2.88.0 — manual Copilot reviewer add will silently no-op."
-    echo "         If copilot is enabled, the loop will still work IF this repo has Automatic Copilot code review enabled."
-    echo "         Run /gh-issue-driven:doctor to confirm setup, or upgrade gh: https://cli.github.com/"
-  fi
+# Strip a leading "v" so a future "gh version v2.88.0" output still parses cleanly.
+GH_VER=$(gh --version 2>/dev/null | awk 'NR==1 {sub(/^v/,"",$3); print $3}')
+# Portable POSIX awk version compare (avoids `sort -V -C` which is GNU-only and
+# silently breaks on macOS/BSD). Compares major.minor against (2, 88); patch is
+# ignored because the floor is 2.88.0. A "-rcN" suffix on the patch is also OK
+# because we don't read v[3] at all. The awk also strips a leading "v" defensively
+# even though the GH_VER capture above already does — both layers are independent.
+if [ -n "$GH_VER" ] && awk -v ver="$GH_VER" 'BEGIN {
+  sub(/^v/, "", ver);
+  split(ver, v, ".");
+  if ((v[1]+0) < 2)  exit 0
+  if ((v[1]+0) > 2)  exit 1
+  if ((v[2]+0) < 88) exit 0
+  exit 1
+}'; then
+  echo "warning: gh CLI $GH_VER is older than 2.88.0 — manual Copilot reviewer add will silently no-op."
+  echo "         If copilot is enabled, the loop will still work IF this repo has Automatic Copilot code review enabled."
+  echo "         Run /gh-issue-driven:doctor to confirm setup, or upgrade gh: https://cli.github.com/"
 fi
 ```
 

--- a/commands/ship.md
+++ b/commands/ship.md
@@ -36,6 +36,23 @@ if [ "$BRANCH" = "$DEFAULT_BRANCH" ]; then
 fi
 ```
 
+#### gh CLI version check (warn-only)
+
+If `copilot.enabled` is true (default), check `gh --version` against the 2.88.0 floor (the version that added real `--add-reviewer @copilot` support per the March 2026 changelog). On older versions the manual reviewer add will silently no-op — the loop still works if the repo has **Automatic Copilot code review** enabled (see `/gh-issue-driven:doctor`), but operators on older `gh` without auto-review will see the loop skip.
+
+```bash
+GH_VER=$(gh --version 2>/dev/null | awk 'NR==1 {print $3}')
+if [ -n "$GH_VER" ]; then
+  if ! printf '%s\n%s\n' '2.88.0' "$GH_VER" | sort -V -C; then
+    echo "warning: gh CLI $GH_VER is older than 2.88.0 — manual Copilot reviewer add will silently no-op."
+    echo "         The loop will still work IF this repo has Automatic Copilot code review enabled."
+    echo "         Run /gh-issue-driven:doctor to confirm setup, or upgrade gh: https://cli.github.com/"
+  fi
+fi
+```
+
+This is a **warn**, not an abort — users on older `gh` with auto-review enabled have a fully working path. The hard error lives in `/gh-issue-driven:doctor` (only when auto-review confirmation is also missing).
+
 Load `~/.claude/cache/gh-issue-driven/<branch>.json`. If missing:
 - Print `no gh-issue-driven state for this branch — running in ship-only mode`
 - Synthesize a minimal `STATE` from current branch + `gh pr list` (to detect if a PR already exists)
@@ -245,21 +262,66 @@ gh pr create \
 
 Capture the PR number and URL into `PR_NUMBER` and `PR_URL`. Update the state file with `pr.number`, `pr.url`, `pr.created_at`, `phase=pr_open`.
 
-### 13. Request Copilot review
+### 13. Request Copilot review (with bounded post-add verification)
 
 Skip if `NO_COPILOT` or `DRY_RUN`.
 
+The plain `gh pr edit --add-reviewer` shell pattern is **not safe** to trust on its own:
+
+- On `gh < 2.88.0`, `--add-reviewer @copilot` exits 0 but the API server-side never queues Copilot. A `|| echo` warning will never fire because the exit code is clean. (Bug A in #15.)
+- On any `gh` version, repos with **Automatic Copilot code review** enabled fire the review independently of the `--add-reviewer` call (the review appears under `latestReviews`, not `reviewRequests`). Checking only `reviewRequests` would falsely conclude "Copilot was not added" and skip the loop, missing a review that's actually coming.
+
+So step 13 issues the add **and** then verifies, polling **two** signals over a bounded short window:
+
 ```bash
 REVIEWER_LOGIN="<from config, default '@copilot'>"
-gh pr edit "$PR_NUMBER" --add-reviewer "$REVIEWER_LOGIN" \
-  || echo "warning: could not add Copilot reviewer (may not be available on this repo)"
+VERIFY_WAIT_SEC="<from config copilot.verification_wait_sec, default 30>"
+
+# Issue the add. Best-effort: a non-zero exit just means "not silently no-op'd" —
+# we still verify after, because exit 0 is also possible on the silent-no-op path.
+gh pr edit "$PR_NUMBER" --add-reviewer "$REVIEWER_LOGIN" >/dev/null 2>&1 || true
+
+# Bounded poll for either signal. Polls every 2s up to VERIFY_WAIT_SEC (default 30s).
+# Mode A's auto-review typically lands within 1-3s of PR creation, so a tight poll
+# interval makes the common case ~3x faster than the original 5s spacing.
+DEADLINE=$(( $(date +%s) + VERIFY_WAIT_SEC ))
+COPILOT_QUEUED=false
+DETECTION_METHOD="neither"
+while [ "$(date +%s)" -lt "$DEADLINE" ]; do
+  DETECTION_METHOD=$(gh pr view "$PR_NUMBER" --json reviewRequests,latestReviews 2>/dev/null \
+    | jq -r '
+        if   ((.reviewRequests // []) | map(.login // .name // "") | any(test("[Cc]opilot"))) then "requested_reviewers"
+        elif ((.latestReviews  // []) | map(.author.login // "")   | any(test("[Cc]opilot"))) then "latest_reviews"
+        else "neither" end
+      ' 2>/dev/null || echo "neither")
+  if [ "$DETECTION_METHOD" != "neither" ]; then
+    COPILOT_QUEUED=true
+    break
+  fi
+  sleep 2
+done
+
+if [ "$COPILOT_QUEUED" = "false" ]; then
+  echo "warning: Copilot reviewer not detected after ${VERIFY_WAIT_SEC}s"
+  echo "         likely cause: gh CLI < 2.88.0 AND Automatic Copilot code review is not enabled on this repo"
+  echo "         see /gh-issue-driven:doctor for setup guidance"
+fi
 ```
 
-If the reviewer add fails, log it but do **not** abort — continue to memory step 15.
+> **JQ filter sync**: the unified `jq -r` expression above is the body of the `detect` function in `tests/copilot-detection.jq` (which the fixture-driven test in `tests/copilot-detection.sh` uses as canonical). They are intentionally byte-equivalent. When you change the detection logic, update **both** in the same commit. CI does not currently diff them — that's tracked as a follow-up.
+
+If `COPILOT_QUEUED` is `false`:
+- Skip step 14 entirely (the polling loop has nothing to wait for).
+- Continue to step 15 (memory) so the session still gets summarized.
+- Persist `copilot.exit_reason="silent_no_op"` and `copilot.detection_method="neither"` in step 14.g's state shape (even though the loop didn't run, the state is the diagnostic record).
+
+If `COPILOT_QUEUED` is `true`, continue to step 14 with `DETECTION_METHOD` carried into the state.
 
 ### 14. Copilot review loop
 
-Skip entirely if `NO_COPILOT` or `DRY_RUN` or step 13 failed to add the reviewer.
+Skip entirely if `NO_COPILOT`, `DRY_RUN`, or `COPILOT_QUEUED=false` from step 13.
+
+When skipping due to `COPILOT_QUEUED=false`, still write the state file at step 14.g's shape with `loops_run=0`, `exit_reason="silent_no_op"`, `detection_method="neither"` so `/gh-issue-driven:status` reports the diagnosis.
 
 Loop up to `copilot.max_loops` (default 5) iterations within this same Claude turn. For each iteration `i` from 1 to max:
 
@@ -286,10 +348,20 @@ Read the JSON from the most recent poll. Identify:
 
 #### 14.c. Exit conditions (check in this order)
 
-1. `REVIEW_DECISION == APPROVED` → break with success.
-2. No new comments AND no `CHANGES_REQUESTED` review since `START_TS` → break ("no actionable feedback").
-3. Iteration counter equals `max_loops` → break ("max loops reached").
-4. New comments are all generic ("looks good", "no issues found", with no diff suggestions) → break.
+Each exit condition sets a specific `exit_reason` so `/gh-issue-driven:status` and post-mortem can distinguish them:
+
+1. `REVIEW_DECISION == APPROVED` → break with `exit_reason="approved"`.
+2. No new comments AND no `CHANGES_REQUESTED` review since `START_TS` → break with `exit_reason="no_actionable_feedback"`.
+3. Iteration counter equals `max_loops` → break with `exit_reason="max_loops"`.
+4. New comments are all generic ("looks good", "no issues found", with no diff suggestions) → break with `exit_reason="no_actionable_feedback"`.
+
+There is also a fifth terminal state set elsewhere in the loop:
+
+5. Tests fail mid-loop in step 14.d → save state with `exit_reason="tests_failed"` and stop the loop without committing.
+
+And a sixth terminal state set in step 13 when the loop is skipped before it ever starts:
+
+6. `COPILOT_QUEUED=false` from step 13 → write state at step 14.g shape with `loops_run=0` and `exit_reason="silent_no_op"`.
 
 #### 14.d. Address actionable comments
 
@@ -332,9 +404,16 @@ gh pr edit "$PR_NUMBER" --add-reviewer "$REVIEWER_LOGIN"
   "loops_run": <i>,
   "max_loops": <max>,
   "last_state": "<REVIEW_DECISION>",
-  "last_polled_at": "<UTC ISO-8601>"
+  "last_polled_at": "<UTC ISO-8601>",
+  "detection_method": "<requested_reviewers|latest_reviews|neither>",
+  "exit_reason": "<approved|no_actionable_feedback|max_loops|tests_failed|silent_no_op>"
 }
 ```
+
+Field semantics:
+
+- `detection_method` is set in step 13's verification and carried unchanged through every loop iteration. It records which signal flagged Copilot as queued — high diagnostic value when investigating "why did the loop run / not run" later.
+- `exit_reason` is `null` (or absent) while the loop is still iterating, and gets its terminal value when one of the exit conditions in 14.c (or step 13's silent-no-op skip, or 14.d's test-failure stop) fires. The five enumerated terminal values are: `approved`, `no_actionable_feedback`, `max_loops`, `tests_failed`, `silent_no_op`.
 
 Continue to the next iteration.
 
@@ -391,7 +470,8 @@ Stop. Do not continue running anything else.
 | Diff is empty | Abort with `nothing to ship`. |
 | `git push` fails | Save state at `phase=gated`, instruct user to retry. |
 | `gh pr create` fails | Save state at `phase=gated`, print the gh error. |
-| Copilot reviewer not available | Skip loop, continue to memory step. |
+| Copilot reviewer not detected after step 13 verification (`COPILOT_QUEUED=false`) | Skip loop, write state with `exit_reason=silent_no_op`, continue to memory step. |
+| `gh < 2.88.0` AND auto-review off | Step 1 emits a warn; step 13's verification then trips `silent_no_op` and skips the loop. |
 | Tests fail mid-loop | Stop loop, save state, report. Do not commit broken code. |
 | Loop hits max iterations | Exit gracefully, leave PR open, tell user to handle remaining feedback manually. |
 

--- a/commands/status.md
+++ b/commands/status.md
@@ -58,8 +58,12 @@ PR      <pr_url>  (#<number>, opened <relative time ago>)
         ... or ... (no PR yet)
 
 Copilot Loop <loops_run>/<max_loops>, last state: <last_state>
+        Detection: <detection_method>   ← (omit line if absent in state)
+        Exit:      <exit_reason>        ← (omit line if absent / loop still in progress)
         Last polled: <relative time>
 ```
+
+The `Detection` and `Exit` lines are produced by `commands/ship.md` step 13 and step 14. They are the post-mortem signal for "did the loop run, and if not, why" — see ship.md step 14.g for the field semantics. If the state file does not have these fields (e.g. the branch was started before they existed, or the loop is still mid-iteration), omit the corresponding line rather than printing `null`. When `exit_reason == "silent_no_op"`, also append a one-line hint pointing at `/gh-issue-driven:doctor` so the operator can confirm Mode A or upgrade gh.
 
 For the live PR state, run:
 
@@ -82,6 +86,8 @@ If `$ARGUMENTS == "all"`:
 
 3. Sort by `started_at` descending.
 4. Print a footer line: `<count> tracked branches.`
+5. If any row has `copilot.exit_reason == "silent_no_op"`, append a single hint after the footer:
+   `Hint: <N> branch(es) hit Copilot silent_no_op — run /gh-issue-driven:doctor to verify Mode A or upgrade gh.`
 
 ### 5. Hint footer
 

--- a/tests/copilot-detection.jq
+++ b/tests/copilot-detection.jq
@@ -18,9 +18,17 @@
 #
 #   { "queued": true|false, "detection_method": "requested_reviewers"|"latest_reviews"|"neither" }
 #
-# Sync requirement: the inline `jq -e` expressions in commands/ship.md step 13 must
-# stay equivalent to this filter. When you change one, change the other in the same
-# commit. (CI does not currently diff them — that's a follow-up.)
+# Sync requirement: the unified `jq -r` expression in commands/ship.md step 13
+# (between `# JQ_DETECT_FILTER_BEGIN` and `# JQ_DETECT_FILTER_END` sentinels) must
+# stay semantically equivalent to this `detect` function — both must produce identical
+# output across every fixture in tests/fixtures/copilot-detection/. They are NOT
+# source-identical: the inline form uses `any(test(...))` while this canonical form
+# uses `map(test(...)) | any`. These are equivalent in jq but not byte-identical.
+#
+# CI enforces semantic equivalence: tests/jq-sync-check.sh extracts the inline
+# filter via the sentinels, runs both filters against every fixture, and asserts
+# identical output strings. When you change one, change the other in the same
+# commit — CI will fail loud otherwise.
 
 def detect:
   . as $pr

--- a/tests/copilot-detection.jq
+++ b/tests/copilot-detection.jq
@@ -1,0 +1,47 @@
+# tests/copilot-detection.jq
+#
+# Canonical detection logic for "is Copilot review actually queued on this PR?"
+# Used by tests/copilot-detection.sh against fixtures in tests/fixtures/copilot-detection/.
+#
+# Input shape (subset of `gh pr view --json reviewRequests,latestReviews` output):
+#
+#   {
+#     "reviewRequests": [
+#       { "login": "...", "name": "..." }
+#     ],
+#     "latestReviews": [
+#       { "author": { "login": "..." }, "state": "COMMENTED|APPROVED|CHANGES_REQUESTED" }
+#     ]
+#   }
+#
+# Output shape:
+#
+#   { "queued": true|false, "detection_method": "requested_reviewers"|"latest_reviews"|"neither" }
+#
+# Sync requirement: the inline `jq -e` expressions in commands/ship.md step 13 must
+# stay equivalent to this filter. When you change one, change the other in the same
+# commit. (CI does not currently diff them — that's a follow-up.)
+
+def detect:
+  . as $pr
+  | (
+      ($pr.reviewRequests // [])
+      | map(.login // .name // "")
+      | map(test("[Cc]opilot"))
+      | any
+    ) as $req
+  | (
+      ($pr.latestReviews // [])
+      | map(.author.login // "")
+      | map(test("[Cc]opilot"))
+      | any
+    ) as $rev
+  | if $req then
+      { queued: true, detection_method: "requested_reviewers" }
+    elif $rev then
+      { queued: true, detection_method: "latest_reviews" }
+    else
+      { queued: false, detection_method: "neither" }
+    end;
+
+detect

--- a/tests/copilot-detection.sh
+++ b/tests/copilot-detection.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# tests/copilot-detection.sh
+#
+# Table-driven test for the Copilot review detection logic in
+# tests/copilot-detection.jq. Asserts each fixture under
+# tests/fixtures/copilot-detection/ produces the expected
+# (queued, detection_method) result.
+#
+# Run from the repo root: bash tests/copilot-detection.sh
+#
+# Exits 0 on all-pass, 1 on any failure or missing dependency.
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
+JQ_FILTER="$REPO_ROOT/tests/copilot-detection.jq"
+FIXTURES_DIR="$REPO_ROOT/tests/fixtures/copilot-detection"
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "FAIL: jq not found on PATH"
+  exit 1
+fi
+
+if [ ! -f "$JQ_FILTER" ]; then
+  echo "FAIL: jq filter not found: $JQ_FILTER"
+  exit 1
+fi
+
+if [ ! -d "$FIXTURES_DIR" ]; then
+  echo "FAIL: fixtures dir not found: $FIXTURES_DIR"
+  exit 1
+fi
+
+PASSED=0
+FAILED=0
+TOTAL=0
+
+# Expectations live next to each fixture in `_fixture_meta` so adding a new
+# detection path means dropping a JSON file with no runner edits.
+for fixture in "$FIXTURES_DIR"/*.json; do
+  name=$(basename "$fixture" .json)
+  TOTAL=$((TOTAL + 1))
+
+  # Use explicit null check — `// empty` would collapse a real `false` expected
+  # value to empty, which is exactly what the silent-no-op / race fixtures use.
+  exp_queued=$(jq -r '._fixture_meta.expected_queued | if . == null then "MISSING" else tostring end' "$fixture")
+  exp_method=$(jq -r '._fixture_meta.expected_detection_method | if . == null then "MISSING" else tostring end' "$fixture")
+
+  if [ "$exp_queued" = "MISSING" ] || [ "$exp_method" = "MISSING" ]; then
+    echo "FAIL $name: fixture is missing _fixture_meta.expected_queued or expected_detection_method"
+    FAILED=$((FAILED + 1))
+    continue
+  fi
+
+  # Strip _fixture_meta before piping to the canonical filter — the production
+  # input never carries it.
+  result=$(jq 'del(._fixture_meta)' "$fixture" | jq -f "$JQ_FILTER")
+  got_queued=$(echo "$result" | jq -r .queued)
+  got_method=$(echo "$result" | jq -r .detection_method)
+
+  if [ "$got_queued" = "$exp_queued" ] && [ "$got_method" = "$exp_method" ]; then
+    printf 'PASS %-20s queued=%s method=%s\n' "$name" "$got_queued" "$got_method"
+    PASSED=$((PASSED + 1))
+  else
+    printf 'FAIL %-20s expected (queued=%s method=%s) got (queued=%s method=%s)\n' \
+      "$name" "$exp_queued" "$exp_method" "$got_queued" "$got_method"
+    FAILED=$((FAILED + 1))
+  fi
+done
+
+echo "---"
+echo "$PASSED passed / $FAILED failed / $TOTAL total"
+
+if [ "$TOTAL" -eq 0 ]; then
+  echo "FAIL: no fixtures found in $FIXTURES_DIR"
+  exit 1
+fi
+
+[ "$FAILED" -eq 0 ]

--- a/tests/copilot-detection.sh
+++ b/tests/copilot-detection.sh
@@ -36,9 +36,22 @@ PASSED=0
 FAILED=0
 TOTAL=0
 
+# Collect fixtures into an array under nullglob so an empty fixtures dir
+# (or a glob with no matches) errors with a clear message instead of
+# iterating once over the literal "$FIXTURES_DIR/*.json" string and tripping
+# `set -e` on the first jq call.
+shopt -s nullglob
+fixtures=("$FIXTURES_DIR"/*.json)
+shopt -u nullglob
+
+if [ ${#fixtures[@]} -eq 0 ]; then
+  echo "FAIL: no fixtures found in $FIXTURES_DIR"
+  exit 1
+fi
+
 # Expectations live next to each fixture in `_fixture_meta` so adding a new
 # detection path means dropping a JSON file with no runner edits.
-for fixture in "$FIXTURES_DIR"/*.json; do
+for fixture in "${fixtures[@]}"; do
   name=$(basename "$fixture" .json)
   TOTAL=$((TOTAL + 1))
 
@@ -72,10 +85,5 @@ done
 
 echo "---"
 echo "$PASSED passed / $FAILED failed / $TOTAL total"
-
-if [ "$TOTAL" -eq 0 ]; then
-  echo "FAIL: no fixtures found in $FIXTURES_DIR"
-  exit 1
-fi
 
 [ "$FAILED" -eq 0 ]

--- a/tests/copilot-detection.sh
+++ b/tests/copilot-detection.sh
@@ -54,10 +54,11 @@ for fixture in "$FIXTURES_DIR"/*.json; do
   fi
 
   # Strip _fixture_meta before piping to the canonical filter — the production
-  # input never carries it.
-  result=$(jq 'del(._fixture_meta)' "$fixture" | jq -f "$JQ_FILTER")
-  got_queued=$(echo "$result" | jq -r .queued)
-  got_method=$(echo "$result" | jq -r .detection_method)
+  # input never carries it. Single pipeline outputs both fields space-separated
+  # so `read` can split them; avoids the `echo "$result" | jq` pattern entirely.
+  read -r got_queued got_method < <(jq 'del(._fixture_meta)' "$fixture" \
+    | jq -rf "$JQ_FILTER" \
+    | jq -r '"\(.queued) \(.detection_method)"')
 
   if [ "$got_queued" = "$exp_queued" ] && [ "$got_method" = "$exp_method" ]; then
     printf 'PASS %-20s queued=%s method=%s\n' "$name" "$got_queued" "$got_method"

--- a/tests/fixtures/copilot-detection/both-signals.json
+++ b/tests/fixtures/copilot-detection/both-signals.json
@@ -1,0 +1,19 @@
+{
+  "reviewRequests": [
+    { "__typename": "Bot", "login": "copilot-pull-request-reviewer" }
+  ],
+  "latestReviews": [
+    {
+      "id": "PRR_kwDOExample",
+      "author": { "login": "copilot-pull-request-reviewer" },
+      "body": "Auto-review fired after manual --add-reviewer.",
+      "state": "COMMENTED",
+      "submittedAt": "2026-04-09T05:50:00Z"
+    }
+  ],
+  "_fixture_meta": {
+    "scenario": "Both signals positive simultaneously: operator manually re-added Copilot via gh pr edit --add-reviewer (populating reviewRequests) AND Mode A's auto-review already fired (populating latestReviews). The detection logic checks signals in priority order — reviewRequests first — so the result is (queued=true, detection_method=requested_reviewers). This fixture locks in the priority-order behavior so future refactors that flip the order would visibly fail.",
+    "expected_queued": true,
+    "expected_detection_method": "requested_reviewers"
+  }
+}

--- a/tests/fixtures/copilot-detection/mode-a-success.json
+++ b/tests/fixtures/copilot-detection/mode-a-success.json
@@ -1,0 +1,17 @@
+{
+  "reviewRequests": [],
+  "latestReviews": [
+    {
+      "id": "PRR_kwDOExample",
+      "author": { "login": "copilot-pull-request-reviewer" },
+      "body": "I reviewed this PR and have a few suggestions.",
+      "state": "COMMENTED",
+      "submittedAt": "2026-04-09T05:30:12Z"
+    }
+  ],
+  "_fixture_meta": {
+    "scenario": "Mode A success: Automatic Copilot code review fired on PR open. reviewRequests is empty (or transient), but Copilot already left a review captured in latestReviews. Loop SHOULD run.",
+    "expected_queued": true,
+    "expected_detection_method": "latest_reviews"
+  }
+}

--- a/tests/fixtures/copilot-detection/mode-b-success.json
+++ b/tests/fixtures/copilot-detection/mode-b-success.json
@@ -1,0 +1,11 @@
+{
+  "reviewRequests": [
+    { "__typename": "Bot", "login": "copilot-pull-request-reviewer" }
+  ],
+  "latestReviews": [],
+  "_fixture_meta": {
+    "scenario": "Mode B success: gh CLI 2.88.0+ successfully queued Copilot via gh pr edit --add-reviewer @copilot",
+    "expected_queued": true,
+    "expected_detection_method": "requested_reviewers"
+  }
+}

--- a/tests/fixtures/copilot-detection/race.json
+++ b/tests/fixtures/copilot-detection/race.json
@@ -1,0 +1,9 @@
+{
+  "reviewRequests": [],
+  "latestReviews": [],
+  "_fixture_meta": {
+    "scenario": "Mode A race: Automatic Copilot code review IS enabled but the auto-review is still in flight on GitHub's side when our 30s bounded wait expires. From the verification's perspective, this is structurally identical to silent-no-op — both signals are empty. We accept the false skip as a known failure mode (logged at WARN). The user can re-run /gh-issue-driven:ship in resume mode (#14) once the review materializes. The fixture exists to document the case and lock in that the detection logic returns the same shape as silent-no-op (so post-mortem of /status output can't tell them apart from JSON alone — only the operator's knowledge of repo settings can).",
+    "expected_queued": false,
+    "expected_detection_method": "neither"
+  }
+}

--- a/tests/fixtures/copilot-detection/silent-no-op.json
+++ b/tests/fixtures/copilot-detection/silent-no-op.json
@@ -1,0 +1,9 @@
+{
+  "reviewRequests": [],
+  "latestReviews": [],
+  "_fixture_meta": {
+    "scenario": "Silent no-op: gh CLI < 2.88.0 + Automatic Copilot code review NOT enabled. gh pr edit --add-reviewer @copilot exited 0 but server-side never queued Copilot, and no auto-review fired. After the bounded wait, both signals remain empty. Loop must skip with exit_reason=silent_no_op.",
+    "expected_queued": false,
+    "expected_detection_method": "neither"
+  }
+}

--- a/tests/jq-sync-check.sh
+++ b/tests/jq-sync-check.sh
@@ -73,11 +73,11 @@ for fixture in "$FIXTURES_DIR"/*.json; do
   TOTAL=$((TOTAL + 1))
 
   # The fixture carries _fixture_meta for the other test runner. Strip it
-  # so the production-shape input is what each filter sees.
-  STRIPPED=$(jq 'del(._fixture_meta)' "$fixture")
-
-  inline_result=$(echo "$STRIPPED" | jq -r "$INLINE_PROGRAM")
-  canonical_result=$(echo "$STRIPPED" | jq -r -f "$CANONICAL_JQ" | jq -r .detection_method)
+  # via direct file → jq pipelines so the production-shape input is what
+  # each filter sees. Avoids `echo "$VAR" | jq` (brittle on escape handling
+  # and on JSON values that look like flags).
+  inline_result=$(jq 'del(._fixture_meta)' "$fixture" | jq -r "$INLINE_PROGRAM")
+  canonical_result=$(jq 'del(._fixture_meta)' "$fixture" | jq -rf "$CANONICAL_JQ" | jq -r .detection_method)
 
   if [ "$inline_result" = "$canonical_result" ]; then
     printf 'SYNC %-20s inline=%s canonical=%s\n' "$name" "$inline_result" "$canonical_result"

--- a/tests/jq-sync-check.sh
+++ b/tests/jq-sync-check.sh
@@ -2,14 +2,23 @@
 # tests/jq-sync-check.sh
 #
 # Mechanically verifies that the inline jq filter in commands/ship.md step 13
-# is byte-equivalent (in produced output, not necessarily in source text) to
-# the canonical detect() function in tests/copilot-detection.jq.
+# is **semantically equivalent** to the canonical detect() function in
+# tests/copilot-detection.jq. The two are intentionally NOT source-identical:
+# the inline form uses `any(test(...))` (predicate), the canonical uses
+# `map(test(...)) | any` (mapped). Both produce the same string for every
+# fixture, which is the contract this script enforces.
+#
+# Important: this check compares the `detection_method` STRING only, not the
+# full `{queued, detection_method}` object. The canonical filter outputs the
+# full object; this script post-processes it via `jq -r .detection_method`
+# before comparing. The `queued` field is not directly diffed because it is
+# fully derivable from `detection_method` (queued == (detection_method != "neither")).
 #
 # How: extracts the inline filter body between `# JQ_DETECT_FILTER_BEGIN` and
 # `# JQ_DETECT_FILTER_END` sentinel comments in ship.md, builds a complete jq
 # program from it, runs it against every fixture in tests/fixtures/copilot-detection/,
-# and compares the result string against running tests/copilot-detection.jq on
-# the same fixture.
+# and compares the resulting `detection_method` string against running
+# tests/copilot-detection.jq on the same fixture.
 #
 # If they ever drift, this exits non-zero and prints the divergence per-fixture
 # so the maintainer can see exactly what changed.
@@ -68,7 +77,20 @@ PASSED=0
 FAILED=0
 TOTAL=0
 
-for fixture in "$FIXTURES_DIR"/*.json; do
+# Collect fixtures into an array under nullglob so an empty fixtures dir
+# (or a glob with no matches) errors with a clear message instead of
+# iterating once over the literal "$FIXTURES_DIR/*.json" string and tripping
+# `set -e` on the first jq call.
+shopt -s nullglob
+fixtures=("$FIXTURES_DIR"/*.json)
+shopt -u nullglob
+
+if [ ${#fixtures[@]} -eq 0 ]; then
+  echo "FAIL: no fixtures found in $FIXTURES_DIR"
+  exit 1
+fi
+
+for fixture in "${fixtures[@]}"; do
   name=$(basename "$fixture" .json)
   TOTAL=$((TOTAL + 1))
 
@@ -90,11 +112,6 @@ done
 
 echo "---"
 echo "$PASSED in sync / $FAILED drifted / $TOTAL total"
-
-if [ "$TOTAL" -eq 0 ]; then
-  echo "FAIL: no fixtures found in $FIXTURES_DIR"
-  exit 1
-fi
 
 if [ "$FAILED" -ne 0 ]; then
   echo

--- a/tests/jq-sync-check.sh
+++ b/tests/jq-sync-check.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# tests/jq-sync-check.sh
+#
+# Mechanically verifies that the inline jq filter in commands/ship.md step 13
+# is byte-equivalent (in produced output, not necessarily in source text) to
+# the canonical detect() function in tests/copilot-detection.jq.
+#
+# How: extracts the inline filter body between `# JQ_DETECT_FILTER_BEGIN` and
+# `# JQ_DETECT_FILTER_END` sentinel comments in ship.md, builds a complete jq
+# program from it, runs it against every fixture in tests/fixtures/copilot-detection/,
+# and compares the result string against running tests/copilot-detection.jq on
+# the same fixture.
+#
+# If they ever drift, this exits non-zero and prints the divergence per-fixture
+# so the maintainer can see exactly what changed.
+#
+# Run from the repo root: bash tests/jq-sync-check.sh
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
+SHIP_MD="$REPO_ROOT/commands/ship.md"
+CANONICAL_JQ="$REPO_ROOT/tests/copilot-detection.jq"
+FIXTURES_DIR="$REPO_ROOT/tests/fixtures/copilot-detection"
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "FAIL: jq not found on PATH"
+  exit 1
+fi
+
+for required in "$SHIP_MD" "$CANONICAL_JQ"; do
+  if [ ! -f "$required" ]; then
+    echo "FAIL: required file missing: $required"
+    exit 1
+  fi
+done
+
+if [ ! -d "$FIXTURES_DIR" ]; then
+  echo "FAIL: fixtures dir missing: $FIXTURES_DIR"
+  exit 1
+fi
+
+# Extract the inline filter body. The sentinels also appear in a prose
+# explanation later in the file, so the state machine must take only the
+# FIRST BEGIN..END run and stop. `&& !capture` keeps re-entering BEGINs
+# from triggering, and `exit` terminates awk on the first matching END
+# so the prose mention is never seen.
+INLINE_BODY=$(awk '
+  /# JQ_DETECT_FILTER_BEGIN/ && !capture { capture = 1; next }
+  /# JQ_DETECT_FILTER_END/   && capture  { exit }
+  capture { print }
+' "$SHIP_MD")
+
+if [ -z "$INLINE_BODY" ]; then
+  echo "FAIL: could not extract inline filter from $SHIP_MD"
+  echo "      expected sentinels: # JQ_DETECT_FILTER_BEGIN ... # JQ_DETECT_FILTER_END"
+  exit 1
+fi
+
+# Compose into a runnable jq program. The canonical detect() returns
+# { queued, detection_method }, but the inline filter returns just the
+# detection_method string. To compare apples to apples, derive the same
+# string from the canonical detect() output.
+INLINE_PROGRAM="$INLINE_BODY"
+
+PASSED=0
+FAILED=0
+TOTAL=0
+
+for fixture in "$FIXTURES_DIR"/*.json; do
+  name=$(basename "$fixture" .json)
+  TOTAL=$((TOTAL + 1))
+
+  # The fixture carries _fixture_meta for the other test runner. Strip it
+  # so the production-shape input is what each filter sees.
+  STRIPPED=$(jq 'del(._fixture_meta)' "$fixture")
+
+  inline_result=$(echo "$STRIPPED" | jq -r "$INLINE_PROGRAM")
+  canonical_result=$(echo "$STRIPPED" | jq -r -f "$CANONICAL_JQ" | jq -r .detection_method)
+
+  if [ "$inline_result" = "$canonical_result" ]; then
+    printf 'SYNC %-20s inline=%s canonical=%s\n' "$name" "$inline_result" "$canonical_result"
+    PASSED=$((PASSED + 1))
+  else
+    printf 'DRIFT %-19s inline=%s canonical=%s\n' "$name" "$inline_result" "$canonical_result"
+    FAILED=$((FAILED + 1))
+  fi
+done
+
+echo "---"
+echo "$PASSED in sync / $FAILED drifted / $TOTAL total"
+
+if [ "$TOTAL" -eq 0 ]; then
+  echo "FAIL: no fixtures found in $FIXTURES_DIR"
+  exit 1
+fi
+
+if [ "$FAILED" -ne 0 ]; then
+  echo
+  echo "ship.md inline jq has drifted from tests/copilot-detection.jq."
+  echo "Update both in the same commit, then re-run this check."
+  exit 1
+fi


### PR DESCRIPTION
Closes #15.

## Summary

- Adds **dual-signal post-add verification** in `ship.md` step 13: bounded 30s wait polling BOTH `reviewRequests` AND `latestReviews`, with a unified jq filter that returns the detection method. Mode A users (Automatic Copilot code review enabled at the repo level) and Mode B users (gh CLI 2.88.0+) both work; users on neither path get a clean `silent_no_op` exit instead of burning the 15-minute polling budget.
- Adds new interactive **"Copilot review setup"** section to `doctor.md`: bounded 7-day cache + AskUserQuestion-driven Mode A confirmation + `sort -V -C` gh version check. Hard-fails only when `gh < 2.88.0` AND Mode A is unconfirmed (the one combination where the loop genuinely cannot work).
- New **5-state `exit_reason`** enum in the state schema (`silent_no_op | no_actionable_feedback | approved | max_loops | tests_failed`) plus `detection_method` (`requested_reviewers | latest_reviews | neither`). `status.md` reads both and renders post-mortem hints when `silent_no_op` fires.
- New **test infrastructure** bootstrapped from zero: canonical jq filter (`tests/copilot-detection.jq`), table-driven runner (`tests/copilot-detection.sh`), 5 fixtures one per detection path including `both-signals.json`, plus a **CI sync check** (`tests/jq-sync-check.sh`) that mechanically extracts the inline ship.md jq via sentinel comments and asserts byte-equivalent output across all fixtures. Wired into `lint.yml`.

## Implementation notes

- The inline ship.md jq and `tests/copilot-detection.jq` are intentionally byte-equivalent on the body of `detect()`. The new `tests/jq-sync-check.sh` enforces this in CI: the awk extractor uses a state machine that exits on the first `# JQ_DETECT_FILTER_END` so the prose mention later in ship.md (which also names both sentinels) is correctly skipped.
- `setup_cache_ttl_days` is hardcoded as a const (7 days) rather than configurable — re-confirming repo settings every 1d vs 14d is not a meaningful operator preference.
- The `doctor.md` trust boundary is now "mostly read-only" with **one** permitted target: `~/.claude/cache/gh-issue-driven/<repo-flat>.copilot-setup.json`, with create/refresh/delete permitted. All other doctor checks remain pure read-only.
- New config keys: `copilot.verification_wait_sec` (default 30) and `copilot.skip_setup_prompt` (default false, CI-friendly).
- README (en + ja) Quickstart now has a **Step 0**: enable Automatic Copilot code review at the repo Settings → Code review page. Manual Web UI fallback documented for users on `gh < 2.88.0` who can't enable Mode A.

## Pre-PR review summary

- audit: pass (de-facto, against `lint.yml` baseline — `claude-c-suite:audit`'s declared `scripts/audit.py` mechanism does not exist in this plugin; filed as a follow-up concern)
- cso: green
- qa-lead: green (yellow on first run with 3 findings; 2 addressed in commit `538341b` — both-signals fixture and CI sync check; 2 deferred to v0.2.0+ alongside #3's broader test infra)
- cto: green
- gate1: yellow via `/claude-c-suite:ask` (COO lens, no escalation) — gate1 caught the Mode A regression risk in the original spec and led to issue #15 being updated with Update 4 (sections A/B/C/D) capturing the additional acceptance criteria

## Follow-up issues filed during this PR

- **#20** doctor `--fix` install hints for missing reviewer plugins (cleanly scoped to v0.1.1)
- **#21** start.md L313 dead `/quality` reference + clarify `/simplify` is built-in

Additional follow-ups identified by gate2 reviewers but not yet filed (will batch into a single issue):
- Loop state machine reachability tests (5 terminal states untested) — coordinate with #3
- status.md backwards-compat tests for state files without new fields
- `claude-c-suite:audit` ↔ plugin layout impedance — either ship `scripts/audit.py` or document `lint.yml`-as-baseline
- `docs/state-schema.md` for `schema_version=1` contract
- CONTRIBUTING.md note locking doctor's trust-boundary discipline
- Plugin-relative path resolution for the inline jq (when Claude Code adds support)

## Local validation

```
copilot-detection.sh: 5 passed / 0 failed / 5 total
jq-sync-check.sh:     5 in sync / 0 drifted / 5 total
check-frontmatter.py: 5 / 5 command files passed
JSON syntax + version sync: ok
```

Full reviews are saved in the plugin cache:
- `~/.claude/cache/gh-issue-driven/15-fix-step-13-14-copilot-reviewer-add-silently.gate1.md`
- `~/.claude/cache/gh-issue-driven/15-fix-step-13-14-copilot-reviewer-add-silently.gate2.md`

🤖 Generated via /gh-issue-driven:ship


---

## Known limitation (filed as #23)

Dogfooding this PR caught a real timing-default flaw: `copilot.verification_wait_sec=30`
is approximately **10x too short** for Mode A's actual auto-review latency on at least
this repo. On the very first live `/gh-issue-driven:ship` run against PR #22 itself, the
step 13 verification produced a **false positive `silent_no_op`**:

| Time (UTC) | Event |
|---|---|
| 06:05:51 | PR created |
| 06:06:33 | step 13 verification began |
| 06:07:01 | step 13 ended (12 polls × 2s ≈ 28s) → recorded `silent_no_op` |
| **06:09:49** | **Copilot review actually fired** (~4 min after PR creation) |

Mode A was enabled all along — the auto-review just took ~4 min. The right fix is
architectural (move silent_no_op detection into step 14's polling loop, drop step 13's
bounded wait entirely), not a default bump. Tracked as **#23**, scheduled for v0.1.1
hardening tail.

This PR is still net positive because:
- The detection function (jq filter) is correct — fixtures all pass
- The state schema additions (`exit_reason`, `detection_method`) are still valid
- The doctor.md Copilot setup section still gives users the right setup guidance
- The only flaw is the timing default in step 13's bounded wait, which #23 will retire

The generalizable lesson captured by dogfooding: **fixtures cannot test latency
assumptions** — only live runs can. Fixture-driven tests catch unit correctness on
shapes; they cannot tell you what the right wait window is. This is a process learning
that applies to any unit-tested function with timing parameters.

## Additional commit (post-Copilot review)

`9df919a` addresses the 5 inline review comments Copilot left:

1. ship.md L47 — gh version check wording (clarify it runs unconditionally)
2. ship.md L313 — "byte-equivalent" → "semantically equivalent" with explicit example
3. tests/copilot-detection.jq — outdated sync comment (CI now diffs them)
4. tests/jq-sync-check.sh — `echo $JSON | jq` → direct `jq | jq` pipeline
5. tests/copilot-detection.sh — same `echo` → `read -r`-from-pipeline pattern

All 5 are concrete improvements; none change the underlying contract. CI still green.
