### PR TITLE
feat: implementation guidance in start.md, draft PR default in ship.md (#31 #16)

### DIFF
--- a/commands/config.md
+++ b/commands/config.md
@@ -118,7 +118,7 @@ Users without kagura-memory installed can ignore this field — recall is skippe
     "skip_setup_prompt": false
   },
   "pr": {
-    "draft_default": false,
+    "draft_default": true,
     "title_template": "{type}: {title} (#{number})"
   },
   "tag": {

--- a/commands/doctor.md
+++ b/commands/doctor.md
@@ -226,36 +226,45 @@ Otherwise:
              /plugin install kagura-memory@kagura-memory-cloud
      ```
 
+10. **Workflow plugin: `feature-dev`** (optional — enhances the implementation phase between `/start` and `/ship`)
+   - Probe via plugin cache glob: `~/.claude/plugins/cache/claude-plugins-official/feature-dev*`.
+   - Warn if missing → `guided feature development (/feature-dev:feature-dev) will not be surfaced in /start step 17`.
+   - When `fix` flag is set AND missing, append:
+     ```
+        try: /plugin install feature-dev
+     ```
+     (Available from the Claude Code official marketplace — no marketplace add needed.)
+
 > Note: the second token in `/plugin install <plugin>@<marketplace>` is the **marketplace name** (the `name` field in the marketplace's `marketplace.json`), NOT the GitHub repository slug. The README's [Install section](../README.md#60-second-quickstart) is the canonical place where the marketplace-name-vs-repo-slug distinction is documented; this `try:` block intentionally mirrors that exact form. If the exact `<plugin>@<marketplace>` syntax differs in your Claude Code version, the marketplace add line is the load-bearing part — you can then use the interactive `/plugin install` UI to pick the plugin from the just-added marketplace.
 
 ### Informational checks
 
-10. **Working tree clean**
+11. **Working tree clean**
     ```bash
     test -z "$(git status --porcelain)"
     ```
     Warn if dirty (but `start` would refuse anyway — this is an early heads-up).
 
-11. **Configuration file**
+12. **Configuration file**
     ```bash
     test -f ~/.claude/gh-issue-driven-config.json && jq empty ~/.claude/gh-issue-driven-config.json
     ```
     - Missing → informational, defaults will be used. Hint: `/gh-issue-driven:config init`.
     - Present but unparseable → warn with the `jq` error.
 
-12. **gh API scope check**
+13. **gh API scope check**
     ```bash
     gh api user --jq .login
     ```
     Just to confirm the auth has API access.
 
-13. **Copilot reviewer reachability** (informational, may be unsupported on some plans)
+14. **Copilot reviewer reachability** (informational, may be unsupported on some plans)
     ```bash
     gh api repos/:owner/:repo/collaborators 2>/dev/null | grep -q copilot
     ```
     Print `✅` / `⚠️ Copilot reviewer not detected — may still work via @copilot mention`.
 
-14. **Stale state files**
+15. **Stale state files**
     List `~/.claude/cache/gh-issue-driven/*.json` and check whether the corresponding branch (decoded from filename) still exists locally:
     ```bash
     git show-ref --verify --quiet refs/heads/<branch>

--- a/commands/ship.md
+++ b/commands/ship.md
@@ -95,7 +95,7 @@ Load `~/.claude/cache/gh-issue-driven/<branch>.json`. If missing:
 
 Load `~/.claude/gh-issue-driven-config.json` over the defaults documented in `/gh-issue-driven:config`. Parse `$ARGUMENTS` into `DRY_RUN`, `FORCE`, `NO_COPILOT`, `DRAFT` booleans. Reject unknown flags.
 
-`DRAFT` defaults to `pr.draft_default` from the effective config (default `false`). The `draft` flag in `$ARGUMENTS` **overrides** this to `true`. There is no flag to force non-draft when `pr.draft_default` is `true` — the operator should set the config value to `false` if they want non-draft as the default.
+`DRAFT` defaults to `pr.draft_default` from the effective config (default `true`). The `draft` flag in `$ARGUMENTS` **overrides** this to `true`. There is no flag to force non-draft when `pr.draft_default` is `true` — the operator should set the config value to `false` if they want non-draft as the default.
 
 When `DRAFT` is `true`, the PR is created with `--draft`. After the Copilot review loop completes with `exit_reason="approved"`, the PR is automatically promoted to ready-for-review:
 

--- a/commands/ship.md
+++ b/commands/ship.md
@@ -542,6 +542,8 @@ gh pr ready "$PR_NUMBER"
 
 If the promotion fails (e.g., permissions), log a warning but do not abort — the PR is still usable as a draft. For any other `exit_reason` (`no_actionable_feedback`, `max_loops`, `tests_failed`, `silent_no_op`), leave the PR as draft.
 
+Update the state file with `pr.state` reflecting the outcome: `"ready"` if promotion succeeded, `"draft"` if it was skipped or failed. This makes the draft→ready transition observable via `/gh-issue-driven:status`.
+
 ### 15. Save the session summary to memory
 
 Skip if `DRY_RUN` or `NO_MEMORY` was set during `start`.

--- a/commands/ship.md
+++ b/commands/ship.md
@@ -95,6 +95,16 @@ Load `~/.claude/cache/gh-issue-driven/<branch>.json`. If missing:
 
 Load `~/.claude/gh-issue-driven-config.json` over the defaults documented in `/gh-issue-driven:config`. Parse `$ARGUMENTS` into `DRY_RUN`, `FORCE`, `NO_COPILOT`, `DRAFT` booleans. Reject unknown flags.
 
+`DRAFT` defaults to `pr.draft_default` from the effective config (default `false`). The `draft` flag in `$ARGUMENTS` **overrides** this to `true`. There is no flag to force non-draft when `pr.draft_default` is `true` — the operator should set the config value to `false` if they want non-draft as the default.
+
+When `DRAFT` is `true`, the PR is created with `--draft`. After the Copilot review loop completes with `exit_reason="approved"`, the PR is automatically promoted to ready-for-review:
+
+```bash
+gh pr ready "$PR_NUMBER"
+```
+
+If the loop exits for any other reason (`no_actionable_feedback`, `max_loops`, `tests_failed`, `silent_no_op`), the PR stays as draft — the operator can manually promote it after reviewing the Copilot feedback.
+
 ### 3. Capture diff context
 
 ```bash
@@ -521,6 +531,16 @@ Field semantics:
 Continue to the next iteration.
 
 After the loop ends (whether by APPROVED, no-feedback, or max-loops), update `phase=pr_open` (Copilot loop is never the final phase — `done` is set only by manual confirmation or merge).
+
+#### 14.h. Promote draft PR on approval
+
+If `DRAFT` is `true` AND `exit_reason` is `"approved"`, promote the PR from draft to ready-for-review:
+
+```bash
+gh pr ready "$PR_NUMBER"
+```
+
+If the promotion fails (e.g., permissions), log a warning but do not abort — the PR is still usable as a draft. For any other `exit_reason` (`no_actionable_feedback`, `max_loops`, `tests_failed`, `silent_no_op`), leave the PR as draft.
 
 ### 15. Save the session summary to memory
 

--- a/commands/start.md
+++ b/commands/start.md
@@ -370,14 +370,51 @@ Gate1   <verdict> (via /<reviewer>[, escalated to /ceo])
 Memory  <k> related contexts found  (top: "<top summary>" score <score>)
         — or — kagura-memory not installed; skipped
         — or — recall returned no results
-
-Next steps:
-  1. Implement the change on this branch.
-  2. Run /simplify (built-in Claude Code skill) to review the diff for reuse,
-     quality, and efficiency before shipping. Address any findings as a
-     follow-up commit on this same branch.
-  3. /gh-issue-driven:ship   ← when implementation is ready
 ```
+
+### 17. Print implementation guidance
+
+After the recap block, print an **implementation guidance** section. This step closes the perceived workflow gap between `/start` and `/ship` by surfacing actionable next steps at the moment the branch is ready.
+
+#### 17a. Extract gate1 key suggestions
+
+Scan `GATE1_OUTPUT` for actionable guidance: look for bullet points, numbered list items, or lines containing "should", "consider", "recommend", "must", "watch out", "risk", "edge case". Extract up to **3** of the most concrete items. If nothing extractable, omit the checklist entirely (do not invent guidance).
+
+Format the extracted items as an indented bullet list:
+
+```
+Gate1 guidance:
+  - <extracted suggestion 1>
+  - <extracted suggestion 2>
+  - <extracted suggestion 3>
+```
+
+If `GATE1_VERDICT` is `unknown` (reviewer skills not installed), omit this sub-section entirely.
+
+#### 17b. Detect available workflow skills
+
+Check the current conversation's system-reminder skill list for the presence of these skills:
+
+- `/feature-dev:feature-dev` — guided feature development (7-phase: discovery → exploration → questions → architecture → implementation → quality review → summary)
+- `/simplify` — built-in Claude Code skill for reviewing changed code
+
+For each detected skill, include it in the suggested workflow below. For skills not detected, omit them silently — do not mention unavailable skills.
+
+#### 17c. Print the suggested workflow
+
+```
+Suggested workflow:
+  1. Implement the change on this branch.
+  2. Run /feature-dev for guided development (optional)      ← only if detected
+  3. Run /simplify to review changed code before shipping.   ← only if detected
+  4. /gh-issue-driven:ship   ← when implementation is ready
+```
+
+Renumber the steps to be contiguous (no gaps if a skill is omitted). Step 1 ("Implement") and the final step (`/ship`) are always present regardless of skill detection.
+
+#### 17d. Respect `lang` setting
+
+When `lang == "ja"`, produce the entire implementation guidance block (gate1 suggestions, suggested workflow) in Japanese. The skill names (`/feature-dev`, `/simplify`, `/ship`) stay as-is (they are command identifiers, not prose).
 
 Stop here. Do not proceed further. The user will implement the change manually and then invoke `/gh-issue-driven:ship`.
 

--- a/commands/start.md
+++ b/commands/start.md
@@ -405,7 +405,7 @@ For each detected skill, include it in the suggested workflow below. For skills 
 ```
 Suggested workflow:
   1. Implement the change on this branch.
-  2. Run /feature-dev for guided development (optional)      ← only if detected
+  2. Run /feature-dev:feature-dev for guided development (optional)      ← only if detected
   3. Run /simplify to review changed code before shipping.   ← only if detected
   4. /gh-issue-driven:ship   ← when implementation is ready
 ```


### PR DESCRIPTION
Closes #31
Closes #16

## Summary
- Add implementation guidance step (step 17) to start.md — extracts gate1 key suggestions, conditionally surfaces `/feature-dev` and `/simplify`, respects `lang` config
- Change `pr.draft_default` from `false` to `true` in config defaults — PRs now open as draft by default
- Add step 14.h to ship.md — auto-promote draft PR to ready-for-review when Copilot review loop exits with `approved`

## Implementation notes
- start.md step 16 (recap) split from new step 17 (implementation guidance) — each step has a single responsibility
- Gate1 suggestion extraction uses heuristic keyword scan ("should", "consider", "recommend", etc.) — pragmatic for v0.1.2
- Skill detection reads the system-reminder skill list — no file I/O or registry queries needed
- Draft promotion failure is warn-only, not abort — PR remains usable as draft

## Pre-PR review summary
- gate2 mode: advisor-only (no binary gate configured)
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: yellow (ship.md default description inconsistency — fixed in follow-up commit)
- cto: yellow (same finding as QA — confirmed fixed)
- gate1: green via /ask

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/31-feat-start-md-add-implementation-guidance-s.gate1.md
- ~/.claude/cache/gh-issue-driven/31-feat-start-md-add-implementation-guidance-s.gate2.md

🤖 Generated via /gh-issue-driven:ship
