### PR TITLE
docs: release checklist as dogfooding gate (#8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes are documented in [GitHub Releases](https://github.com/JFK/g
 
 ## [v0.2.0](https://github.com/JFK/gh-issue-driven/releases/tag/v0.2.0) — 2026-04-10
 
-> **Dogfooding checklist exemption**: v0.2.0 was tagged before the [Release checklist](CONTRIBUTING.md#release-checklist--dogfooding-gate) was established (see #8, landed in v0.2.1). This release has no dogfooding evidence bundle attached. v0.2.1 is the first release required to follow the checklist.
+> **Dogfooding checklist exemption**: v0.2.0 was tagged before the [Release checklist](CONTRIBUTING.md#release-checklist--dogfooding-gate) was established (see #8, introduced after v0.2.0). This release has no dogfooding evidence bundle attached. Releases after v0.2.0 are required to follow the checklist.
 
 ## [v0.1.2](https://github.com/JFK/gh-issue-driven/releases/tag/v0.1.2) — 2026-04-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes are documented in [GitHub Releases](https://github.com/JFK/g
 
 ## [v0.2.0](https://github.com/JFK/gh-issue-driven/releases/tag/v0.2.0) — 2026-04-10
 
+> **Dogfooding checklist exemption**: v0.2.0 was tagged before the [Release checklist](CONTRIBUTING.md#release-checklist--dogfooding-gate) was established (see #8, landed in v0.2.1). This release has no dogfooding evidence bundle attached. v0.2.1 is the first release required to follow the checklist.
+
 ## [v0.1.2](https://github.com/JFK/gh-issue-driven/releases/tag/v0.1.2) — 2026-04-10
 
 ## [v0.1.1](https://github.com/JFK/gh-issue-driven/releases/tag/v0.1.1) — 2026-04-10

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,10 +107,10 @@ Variation release-to-release is fine — the point is a consistent minimum that 
 A dogfooding run **passes** when:
 
 1. It reaches `phase=done` in the state file (manual confirmation or merged), **or**
-2. It reaches `phase=pr_open` and the PR is subsequently merged during the release window, **or**
+2. It reaches `phase=pr_open` and the PR is subsequently merged before the release tag for that release is cut, **or**
 3. It stopped at a gate with an explicit maintainer override documented in the release notes ("gate2 yellow: <reason>, proceeding with --force").
 
-A run that aborted at `phase=designed` or `phase=gated` without an override does **not** count — that is a checkbox, not evidence. Note: the state file's `phase` field is set by `/gh-issue-driven:start` and `/gh-issue-driven:ship` — `done` is the terminal value written only by manual confirmation or merge; the intermediate values are `designed` (gate1 passed) → `gated` (gate2 passed) → `pr_open` (PR created).
+A run that aborted at `phase=designed` or `phase=gated` without an override does **not** count — that is a checkbox, not evidence. The `phase` field is set by `/gh-issue-driven:start` and `/gh-issue-driven:ship`; `done` is the terminal value written by manual confirmation or merge, and `pr_open` is the phase after `/ship` creates the PR. See `commands/start.md`, `commands/ship.md`, and `commands/review.md` for the full phase state machine.
 
 #### Dogfooding recovery
 
@@ -124,13 +124,24 @@ If a run aborts mid-flow (gate red, test failure, `silent_no_op`, branch protect
 
 #### Release steps
 
-Once the dogfooding gate is satisfied:
+Once the dogfooding gate is satisfied, follow **one** of the two paths below.
+
+**Recommended — automated path**: on a clean working tree on `main`, run:
+
+```bash
+/gh-issue-driven:tag
+```
+
+`/gh-issue-driven:tag` requires a clean tree and performs the version bump (`plugin.json` + `marketplace.json`), CHANGELOG update, commit, tag, push, and GitHub Release creation in one atomic ceremony. Do **not** pre-edit `plugin.json` / `marketplace.json` / `CHANGELOG.md` before running it — `/tag` owns those files and will abort on a dirty tree. After `/tag` finishes, edit the created GitHub Release to paste the dogfooding evidence bundle. `/tag` does **not** attach evidence automatically; evidence attach is tracked as a future enhancement in #43.
+
+**Manual path** (when `/tag` is unavailable or you need a custom ceremony):
 
 1. Bump `version` in **both** `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json` (CI enforces sync).
-2. Update CHANGELOG with the new entry.
-3. `/gh-issue-driven:tag` (recommended — automates steps 3–5, including dogfooding evidence attachment). Or manually: `git tag vX.Y.Z && git push origin main --tags`.
-4. Draft or edit the GitHub Release pointing at the new tag; paste the evidence bundle from each dogfooding run.
-5. Marketplace auto-discovers the new version.
+2. Update `CHANGELOG.md` with the new entry.
+3. Commit: `git commit -am "chore: release v<X.Y.Z>"`
+4. Tag and push: `git tag v<X.Y.Z> && git push origin main --tags`
+5. `gh release create v<X.Y.Z> --generate-notes`, then edit to paste the dogfooding evidence bundle.
+6. Marketplace auto-discovers the new version.
 
 ## Code of conduct
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,10 +73,63 @@ If you maintain a c-suite or phd-panel skill, **adding the Verdict line is the s
 
 ## Releasing
 
+Releases have two parts: the **release checklist** (dogfooding gate, below) and the mechanical tag-and-push ceremony (`/gh-issue-driven:tag` automates steps 1–5).
+
+### Release checklist — dogfooding gate
+
+**Rule**: before cutting any `v*` tag, `/gh-issue-driven:start` + `/gh-issue-driven:ship` must be run end-to-end against representative issues. Output evidence from each run is attached to the release notes. The purpose is to make dogfooding a hard gate, not a hope — each release proves the plugin works on itself before shipping.
+
+#### Required run count by release type
+
+| Release type | Runs required | Representative issues |
+|---|---|---|
+| `patch` (`x.y.Z → x.y.Z+1`) | **1** | The most representative fix in the release (typically *the* headline fix). In many cases, the release PR itself is the dogfooding run — no extra work needed. |
+| `minor` (`x.Y.z → x.Y+1.0`) | **3** | 1 trivial typo, 1 mid-size feature, 1 cross-cutting redesign. |
+| `major` (`X.y.z → X+1.0.0`) | **3** | Same 3 categories as minor, **plus** explicit sign-off from CSO and CTO reviewer skills (`/claude-c-suite:cso` and `/claude-c-suite:cto`) captured in the release notes. |
+
+If a required category has no representative issue in the current cycle (e.g. a clean patch with no typos in the backlog), substitute with the next-closest-grain item — a README tweak or comment fix for the typo slot, the largest spec-surface feature for the cross-cutting slot. Document the substitution in the release notes.
+
+#### Evidence bundle schema (minimum)
+
+For each dogfooding run, attach the following to the release notes as a markdown code block or linked release artifact:
+
+```
+- state JSON: ~/.claude/cache/gh-issue-driven/<branch-flat>.json
+- gate1.md:   ~/.claude/cache/gh-issue-driven/<branch-flat>.gate1.md
+- gate2.md:   ~/.claude/cache/gh-issue-driven/<branch-flat>.gate2.md  (if gate2 ran)
+- PR URL:     https://github.com/<owner>/<repo>/pull/<N>
+```
+
+Variation release-to-release is fine — the point is a consistent minimum that lets a reviewer reconstruct what happened.
+
+#### Pass criterion
+
+A dogfooding run **passes** when:
+
+1. It reaches `phase=done` in the state file (manual confirmation or merged), **or**
+2. It reaches `phase=pr_open` and the PR is subsequently merged during the release window, **or**
+3. It stopped at a gate with an explicit maintainer override documented in the release notes ("gate2 yellow: <reason>, proceeding with --force").
+
+A run that aborted at `phase=designed` or `phase=gated` without an override does **not** count — that is a checkbox, not evidence. Note: the state file's `phase` field is set by `/gh-issue-driven:start` and `/gh-issue-driven:ship` — `done` is the terminal value written only by manual confirmation or merge; the intermediate values are `designed` (gate1 passed) → `gated` (gate2 passed) → `pr_open` (PR created).
+
+#### Dogfooding recovery
+
+If a run aborts mid-flow (gate red, test failure, `silent_no_op`, branch protection block during `/tag`):
+
+- **Do NOT rerun from scratch** after `/gh-issue-driven:tag` steps 7–10 have mutated files. Re-running duplicates CHANGELOG entries, re-bumps manifests, and fails on tag collision. Recover from the point of failure step by step.
+- **Do** capture the failure state in the release notes: `Dogfooding run N — aborted at phase X, reason: Y`.
+- A failed dogfooding run does **not** automatically block the release. It requires maintainer judgment:
+  - **Real regression** → fix the underlying issue, rerun the relevant dogfooding run, and only tag once it passes.
+  - **Flaky gate signal** (non-deterministic advisor yellow, transient API error, environmental hiccup) → document the reason and proceed. Gate yellow from an advisor is advisory, not a release blocker.
+
+#### Release steps
+
+Once the dogfooding gate is satisfied:
+
 1. Bump `version` in **both** `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json` (CI enforces sync).
-2. Update CHANGELOG (when one exists).
-3. `git tag vX.Y.Z && git push origin main --tags`
-4. Draft a GitHub Release pointing at the new tag.
+2. Update CHANGELOG with the new entry.
+3. `/gh-issue-driven:tag` (recommended — automates steps 3–5, including dogfooding evidence attachment). Or manually: `git tag vX.Y.Z && git push origin main --tags`.
+4. Draft or edit the GitHub Release pointing at the new tag; paste the evidence bundle from each dogfooding run.
 5. Marketplace auto-discovers the new version.
 
 ## Code of conduct

--- a/README.md
+++ b/README.md
@@ -295,6 +295,8 @@ See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 CI runs `lint.yml` on every push and PR — JSON syntax, version sync, name sync, and command frontmatter parseability.
 
+Before cutting any `v*` tag, maintainers follow the [Release checklist (dogfooding gate)](CONTRIBUTING.md#release-checklist--dogfooding-gate): `patch` releases require 1 representative run, `minor`/`major` releases require 3 runs across typo / mid-size feature / cross-cutting categories, with evidence attached to the release notes.
+
 ---
 
 ## License


### PR DESCRIPTION
Closes #8

## Summary

- Adds a "Release checklist — dogfooding gate" section to `CONTRIBUTING.md` that makes end-to-end `/start` + `/ship` runs a mandatory release gate, with a staged cadence (patch=1 run, minor/major=3 runs) to keep ops sustainable on a single-maintainer project.
- Defines the evidence bundle minimum schema (state JSON + gate1/gate2.md + PR URL), the pass criterion (`phase=done`, merged in release window, or documented override), and a dogfooding recovery runbook for mid-flow aborts.
- `CHANGELOG.md` gets an exemption note for v0.2.0 — it was tagged before this checklist existed, so v0.2.1 is the first release required to follow it. Makes the retroactive gap auditable.
- `README.md` Development section links to the new anchor.

## Implementation notes

Design went through QA Lead → PM → COO review during gate1, producing 5 required edits vs the original issue body:

1. **Staged cadence** (PM + COO consensus): a blanket 3-runs rule would stall patch bumps — ~75% of the first week's releases — against a single maintainer. `patch=1` lets the release PR itself serve as the dogfooding run.
2. **Acceptance criterion retargeted to v0.2.1** (PM): the original issue said "v0.2.0 is the first" but v0.2.0 was already tagged 2026-04-10. CHANGELOG gets a v0.2.0 exemption note to keep the gap auditable.
3. **Optional CI workflow carved out to #43** (QA + PM): the `release-checklist.yml` workflow mentioned in the issue body was deliberately scoped out to avoid crosstalk. Filed as a v0.3.0 follow-up blocked on #10 (eval framework), which defines the canonical gate output shape the workflow must parse.
4. **Evidence bundle schema** (QA): minimum files listed explicitly so reviewers can reconstruct what happened 3 months later.
5. **Recovery runbook** (COO): reuses the v0.1.1+ learning that `/gh-issue-driven:tag` steps 7–10 are non-idempotent — never rerun from scratch after file mutations, recover from the point of failure.

Gate2 yellow (CSO green, QA yellow, CTO yellow) caught one critical inconsistency: the original draft wrote `phase=shipped` as a pass criterion, but `shipped` is not an actual phase value in the state schema — the real terminal phases are `designed` → `gated` → `pr_open` → `done` (ship.md 14.g). Fixed in the commit via amend before this PR was opened.

## Pre-PR review summary

- gate2 mode: advisor-only (no binary gate configured)
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: yellow
- cto: yellow
- gate1: yellow via /ask (with PM and COO follow-up consultation)
- review provider: copilot

## Known-issues for Copilot review

Gate2 yellow left three minor items that weren't blockers but are worth tightening in-loop:

1. **"Release PR itself counts" needs 1-sentence clarification** — the current wording in the `patch` row ("the release PR itself is the dogfooding run") is circular-sounding. Suggest adding: "For patch bumps, the act of shipping the release PR itself via `/start` + `/ship` counts as the single required dogfooding run — no separate run needed."
2. **"Release window" is not defined** — pass criterion #2 says "merged during the release window" without specifying how long the window is. Suggest "merged within 7 days of the dogfooding run" or similar.
3. **Anchor link render verification** — `CONTRIBUTING.md#release-checklist--dogfooding-gate` uses a double hyphen because github-slugger strips em-dashes and leaves the surrounding spaces as separate hyphens. This should be validated against the actual rendered markdown in the PR preview; if broken, fall back to `#release-checklist-dogfooding-gate` (single hyphen).

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/8-docs-release-checklist-in-contributing-dogfoo.gate1.md
- ~/.claude/cache/gh-issue-driven/8-docs-release-checklist-in-contributing-dogfoo.gate2.md

🤖 Generated via /gh-issue-driven:ship
