### PR TITLE
feat(doctor): surface skill origin URLs from plugin metadata (#9)

### DIFF
--- a/commands/config.md
+++ b/commands/config.md
@@ -77,6 +77,27 @@ When `true` (default), `ship.md` step 13c and `review.md` step 5 pause before en
 
 **Set to `false`** to restore the pre-v0.3.0 behavior exactly (no prompt, no `hitl_*` fields in state). Useful for CI or non-interactive environments where the operator cannot respond to AskUserQuestion.
 
+### `doctor.expected_origins`
+
+Object mapping plugin skill names to their expected canonical HTTPS repository URLs. When set, `doctor` reads each installed plugin's `plugin.json` from the cache and compares its `repository` field against the configured value. A mismatch emits a `⚠️ WARN origin mismatch` line — a supply-chain hygiene check that catches a plugin being silently replaced by a fork or a same-name impersonator.
+
+**Default** maps the four plugins gh-issue-driven depends on to their canonical origins:
+
+```json
+{
+  "claude-c-suite":   "https://github.com/JFK/claude-c-suite-plugin",
+  "claude-phd-panel": "https://github.com/JFK/claude-phd-panel-plugin",
+  "kagura-memory":    "https://github.com/kagura-ai/memory-cloud",
+  "feature-dev":      null
+}
+```
+
+Set a key to `null` to skip the origin check for that plugin (any origin is accepted). `feature-dev` defaults to `null` because official Anthropic plugins carry no `repository` field in their `plugin.json`.
+
+To trust a fork, change the URL: `"claude-c-suite": "https://github.com/yourfork/claude-c-suite-plugin"`. Comparison is case-sensitive exact string match — write the URL exactly as it appears in the plugin's own `plugin.json` (no trailing slash, HTTPS, no `.git` suffix).
+
+**CI use**: run `doctor verbose` and `grep '^PLUGIN_CHECK'` to parse machine-readable `key=value` lines. Fail on `status=unexpected` to enforce origin pinning in CI.
+
 ### `memory.context_id`
 
 Accepts three forms — in priority order of recommendation:
@@ -189,7 +210,15 @@ Users without kagura-memory installed can ignore this field — recall is skippe
     "default_group": "Other",
     "auto_close_milestone": false
   },
-  "dry_run_env_var": "GH_ISSUE_DRY_RUN"
+  "dry_run_env_var": "GH_ISSUE_DRY_RUN",
+  "doctor": {
+    "expected_origins": {
+      "claude-c-suite":   "https://github.com/JFK/claude-c-suite-plugin",
+      "claude-phd-panel": "https://github.com/JFK/claude-phd-panel-plugin",
+      "kagura-memory":    "https://github.com/kagura-ai/memory-cloud",
+      "feature-dev":      null
+    }
+  }
 }
 ```
 

--- a/commands/config.md
+++ b/commands/config.md
@@ -79,7 +79,7 @@ When `true` (default), `ship.md` step 13c and `review.md` step 5 pause before en
 
 ### `doctor.expected_origins`
 
-Object mapping plugin skill names to their expected canonical HTTPS repository URLs. When set, `doctor` reads each installed plugin's `plugin.json` from the cache and compares its `repository` field against the configured value. A mismatch emits a `⚠️ WARN origin mismatch` line — a supply-chain hygiene check that catches a plugin being silently replaced by a fork or a same-name impersonator.
+Object mapping plugin skill names to their expected canonical HTTPS repository URLs. When set, `doctor` reads each installed plugin's `plugin.json` from the cache and compares its `repository` field against the configured value. A mismatch emits a `⚠️  <skill>: origin mismatch: ...` line — a supply-chain hygiene check that catches a plugin being silently replaced by a fork or a same-name impersonator.
 
 **Default** maps the four plugins gh-issue-driven depends on to their canonical origins:
 

--- a/commands/doctor.md
+++ b/commands/doctor.md
@@ -347,18 +347,18 @@ CI scripts can parse with `grep '^PLUGIN_CHECK'` and fail on `status=unexpected`
      ```
 
 10. **Workflow plugin: `feature-dev`** (optional — enhances the implementation phase between `/start` and `/ship`)
-    - Probe via plugin cache glob: `~/.claude/plugins/cache/claude-plugins-official/feature-dev*`.
-    - Run the Plugin Metadata Resolution Procedure with:
-      - `PMRP_GLOB=claude-plugins-official/feature-dev*`
-      - `PMRP_SKILL=feature-dev`
-      - `PMRP_OFFICIAL=true`
-    - If `PLUGIN_FOUND=false`: emit `⚠️  feature-dev: not installed — guided feature development (/feature-dev:feature-dev) will not be surfaced in /start step 17`.
-    - Otherwise: emit the status line per the procedure's output format.
-    - When `fix` flag is set AND missing, append:
-      ```
-         try: /plugin install feature-dev
-      ```
-      (Available from the Claude Code official marketplace — no marketplace add needed.)
+   - Probe via plugin cache glob: `~/.claude/plugins/cache/claude-plugins-official/feature-dev*`.
+   - Run the Plugin Metadata Resolution Procedure with:
+     - `PMRP_GLOB=claude-plugins-official/feature-dev*`
+     - `PMRP_SKILL=feature-dev`
+     - `PMRP_OFFICIAL=true`
+   - If `PLUGIN_FOUND=false`: emit `⚠️  feature-dev: not installed — guided feature development (/feature-dev:feature-dev) will not be surfaced in /start step 17`.
+   - Otherwise: emit the status line per the procedure's output format.
+   - When `fix` flag is set AND missing, append:
+     ```
+        try: /plugin install feature-dev
+     ```
+     (Available from the Claude Code official marketplace — no marketplace add needed.)
 
 > Note: the second token in `/plugin install <plugin>@<marketplace>` is the **marketplace name** (the `name` field in the marketplace's `marketplace.json`), NOT the GitHub repository slug. The README's [Install section](../README.md#60-second-quickstart) is the canonical place where the marketplace-name-vs-repo-slug distinction is documented; this `try:` block intentionally mirrors that exact form. If the exact `<plugin>@<marketplace>` syntax differs in your Claude Code version, the marketplace add line is the load-bearing part — you can then use the interactive `/plugin install` UI to pick the plugin from the just-added marketplace.
 

--- a/commands/doctor.md
+++ b/commands/doctor.md
@@ -211,6 +211,7 @@ This procedure is called by each plugin check (steps 7-10) to probe presence, re
 - `PLUGIN_ORIGIN_DISPLAY` — formatted string for the output line
 - `PLUGIN_ORIGIN_STATUS` — one of: `official`, `expected`, `unexpected`, `unchecked`, `no-metadata`, `corrupt`, `absent`
 - `PLUGIN_VERSION` — version string or `unknown`
+- `PMRP_REPO` — raw repository URL or empty string; left in scope for callers that emit verbose `origin=...` lines
 
 **Algorithm**:
 

--- a/commands/doctor.md
+++ b/commands/doctor.md
@@ -197,9 +197,119 @@ Otherwise:
    ```
    Fail → `cannot write to ~/.claude/cache/gh-issue-driven`.
 
+#### Plugin Metadata Resolution Procedure
+
+This procedure is called by each plugin check (steps 7-10) to probe presence, read metadata, and verify origin. Run it in the same shell context as the calling step.
+
+**Inputs** (supplied by the calling step):
+- `PMRP_GLOB` — glob pattern relative to `~/.claude/plugins/cache/` that identifies the plugin's cache root (e.g. `claude-c-suite*`)
+- `PMRP_SKILL` — plugin skill name, used for display and as the lookup key in `doctor.expected_origins` (e.g. `claude-c-suite`)
+- `PMRP_OFFICIAL` — `true` if the plugin lives under `claude-plugins-official/`, otherwise `false`
+
+**Outputs** (read by the calling step to decide the emoji line):
+- `PLUGIN_FOUND` — `true`/`false`
+- `PLUGIN_ORIGIN_DISPLAY` — formatted string for the output line
+- `PLUGIN_ORIGIN_STATUS` — one of: `official`, `expected`, `unexpected`, `unchecked`, `no-metadata`, `corrupt`, `absent`
+- `PLUGIN_VERSION` — version string or `unknown`
+
+**Algorithm**:
+
+```bash
+set -euo pipefail
+
+# Step 1 — Find plugin root(s) in the cache.
+PMRP_ROOTS=$(ls -d ~/.claude/plugins/cache/${PMRP_GLOB} 2>/dev/null || true)
+if [ -z "$PMRP_ROOTS" ]; then
+  PLUGIN_FOUND=false
+  PLUGIN_ORIGIN_DISPLAY="(not installed)"
+  PLUGIN_ORIGIN_STATUS="absent"
+  PLUGIN_VERSION="none"
+  return  # caller emits ⚠️ missing line
+fi
+PLUGIN_FOUND=true
+
+# Step 2 — Locate plugin.json candidates under the root(s).
+PMRP_JSONS=$(find $PMRP_ROOTS -maxdepth 4 -name plugin.json \
+             -path '*/.claude-plugin/plugin.json' 2>/dev/null | sort)
+
+if [ -z "$PMRP_JSONS" ]; then
+  PLUGIN_ORIGIN_DISPLAY="installed (no plugin.json found)"
+  PLUGIN_ORIGIN_STATUS="no-metadata"
+  PLUGIN_VERSION="unknown"
+  return
+fi
+
+# Step 3 — Select the canonical plugin.json (latest version by lex sort).
+PMRP_JSON=$(echo "$PMRP_JSONS" | tail -1)
+
+# Step 4 — Parse the JSON. Surface parse errors without aborting.
+if ! jq empty "$PMRP_JSON" 2>/dev/null; then
+  PLUGIN_ORIGIN_DISPLAY="installed (plugin.json corrupt)"
+  PLUGIN_ORIGIN_STATUS="corrupt"
+  PLUGIN_VERSION="unknown"
+  return
+fi
+
+PMRP_REPO=$(jq -r '.repository // empty' "$PMRP_JSON")
+PMRP_VER=$(jq -r '.version // empty' "$PMRP_JSON")
+PLUGIN_VERSION="${PMRP_VER:-unknown}"
+
+# Step 5 — Classify origin.
+if [ "$PMRP_OFFICIAL" = "true" ]; then
+  PLUGIN_ORIGIN_DISPLAY="claude-plugins-official (official)"
+  PLUGIN_ORIGIN_STATUS="official"
+elif [ -z "$PMRP_REPO" ]; then
+  PLUGIN_ORIGIN_DISPLAY="installed (no repository field in plugin.json)"
+  PLUGIN_ORIGIN_STATUS="no-metadata"
+else
+  # Look up expected origin from effective config.
+  PMRP_EXPECTED=$(jq -r --arg k "$PMRP_SKILL" \
+    '.doctor.expected_origins[$k] // empty' <(merged-effective-config-json))
+
+  # Strip https:// for display.
+  PMRP_DISPLAY_URL=$(echo "$PMRP_REPO" | sed 's|^https://||')
+
+  if [ -z "$PMRP_EXPECTED" ]; then
+    PLUGIN_ORIGIN_DISPLAY="${PMRP_DISPLAY_URL}@v${PLUGIN_VERSION}"
+    PLUGIN_ORIGIN_STATUS="unchecked"
+  elif [ "$PMRP_REPO" = "$PMRP_EXPECTED" ]; then
+    PLUGIN_ORIGIN_DISPLAY="${PMRP_DISPLAY_URL}@v${PLUGIN_VERSION}"
+    PLUGIN_ORIGIN_STATUS="expected"
+  else
+    PMRP_EXP_DISPLAY=$(echo "$PMRP_EXPECTED" | sed 's|^https://||')
+    PLUGIN_ORIGIN_DISPLAY="origin mismatch: expected ${PMRP_EXP_DISPLAY}, got ${PMRP_DISPLAY_URL}@v${PLUGIN_VERSION}"
+    PLUGIN_ORIGIN_STATUS="unexpected"
+  fi
+fi
+```
+
+**Output line format** (caller emits after the procedure returns). Uses the same `✅ <name>` / `⚠️  <name>: <reason>` format as all other doctor checks (lines 35-38):
+
+| `PLUGIN_ORIGIN_STATUS` | Emoji | Line |
+|---|---|---|
+| `official`, `expected`, `unchecked` | `✅` | `✅ <PMRP_SKILL>: <PLUGIN_ORIGIN_DISPLAY>` |
+| `no-metadata`, `corrupt` | `⚠️` | `⚠️  <PMRP_SKILL>: <PLUGIN_ORIGIN_DISPLAY>` |
+| `unexpected` | `⚠️` | `⚠️  <PMRP_SKILL>: <PLUGIN_ORIGIN_DISPLAY>` |
+| `absent` | `⚠️` | `⚠️  <PMRP_SKILL>: <degradation message from calling step>` |
+
+When the `verbose` flag is set, also emit a machine-readable line **before** each emoji line:
+
+```
+PLUGIN_CHECK skill=<PMRP_SKILL> found=<true|false> status=<PLUGIN_ORIGIN_STATUS> version=<PLUGIN_VERSION> origin=<raw-repository-url-or-empty>
+```
+
+CI scripts can parse with `grep '^PLUGIN_CHECK'` and fail on `status=unexpected`.
+
+---
+
 7. **Reviewer plugin: `claude-c-suite`**
-   - Probe: search for any of `~/.claude/plugins/cache/claude-c-suite*` (glob), or attempt a no-op invocation of the Skill tool with `/claude-c-suite:ask` and detect "skill not found".
-   - Warn if missing → `gate1/gate2 will degrade to advisory-only`.
+   - Probe: glob `~/.claude/plugins/cache/claude-c-suite*`, or attempt a no-op invocation of the Skill tool with `/claude-c-suite:ask` and detect "skill not found".
+   - Run the Plugin Metadata Resolution Procedure with:
+     - `PMRP_GLOB=claude-c-suite*`
+     - `PMRP_SKILL=claude-c-suite`
+     - `PMRP_OFFICIAL=false`
+   - If `PLUGIN_FOUND=false`: emit `⚠️  claude-c-suite: not installed — gate1/gate2 will degrade to advisory-only`.
+   - Otherwise: emit the status line per the procedure's output format.
    - When `fix` flag is set AND missing, append a 2-line `try:` block:
      ```
         try: /plugin marketplace add JFK/claude-c-suite-plugin
@@ -208,7 +318,12 @@ Otherwise:
 
 8. **Reviewer plugin: `claude-phd-panel`** (optional but recommended for v0.2 features)
    - Probe via plugin cache glob.
-   - Warn if missing — does not block v0.1.0 functionality.
+   - Run the Plugin Metadata Resolution Procedure with:
+     - `PMRP_GLOB=claude-phd-panel*`
+     - `PMRP_SKILL=claude-phd-panel`
+     - `PMRP_OFFICIAL=false`
+   - If `PLUGIN_FOUND=false`: emit `⚠️  claude-phd-panel: not installed — does not block v0.1.0 functionality`.
+   - Otherwise: emit the status line per the procedure's output format.
    - When `fix` flag is set AND missing, append a 2-line `try:` block:
      ```
         try: /plugin marketplace add JFK/claude-phd-panel-plugin
@@ -216,8 +331,14 @@ Otherwise:
      ```
 
 9. **Memory plugin: `kagura-memory`**
-   - Probe: check if the `mcp__kagura-memory__recall` tool is callable, OR glob `~/.claude/plugins/cache/*kagura-memory*`.
-   - Warn if missing → `recall and session-start/summary will be skipped`.
+   - Probe: glob `~/.claude/plugins/cache/*kagura-memory*`, or check if the `mcp__kagura-memory__recall` tool is callable.
+   - Run the Plugin Metadata Resolution Procedure with:
+     - `PMRP_GLOB=*kagura-memory*`
+     - `PMRP_SKILL=kagura-memory`
+     - `PMRP_OFFICIAL=false`
+   - If `PLUGIN_FOUND=false` via glob but the MCP tool is callable: emit `✅ kagura-memory: installed via MCP (cache path not found, origin not verified)`.
+   - If both miss: emit `⚠️  kagura-memory: not installed — recall and session-start/summary will be skipped`.
+   - Otherwise: emit the status line per the procedure's output format.
    - When `fix` flag is set AND missing, append a 2-line `try:` block:
      ```
         try: /plugin marketplace add kagura-ai/memory-cloud
@@ -225,13 +346,18 @@ Otherwise:
      ```
 
 10. **Workflow plugin: `feature-dev`** (optional — enhances the implementation phase between `/start` and `/ship`)
-   - Probe via plugin cache glob: `~/.claude/plugins/cache/claude-plugins-official/feature-dev*`.
-   - Warn if missing → `guided feature development (/feature-dev:feature-dev) will not be surfaced in /start step 17`.
-   - When `fix` flag is set AND missing, append:
-     ```
-        try: /plugin install feature-dev
-     ```
-     (Available from the Claude Code official marketplace — no marketplace add needed.)
+    - Probe via plugin cache glob: `~/.claude/plugins/cache/claude-plugins-official/feature-dev*`.
+    - Run the Plugin Metadata Resolution Procedure with:
+      - `PMRP_GLOB=claude-plugins-official/feature-dev*`
+      - `PMRP_SKILL=feature-dev`
+      - `PMRP_OFFICIAL=true`
+    - If `PLUGIN_FOUND=false`: emit `⚠️  feature-dev: not installed — guided feature development (/feature-dev:feature-dev) will not be surfaced in /start step 17`.
+    - Otherwise: emit the status line per the procedure's output format.
+    - When `fix` flag is set AND missing, append:
+      ```
+         try: /plugin install feature-dev
+      ```
+      (Available from the Claude Code official marketplace — no marketplace add needed.)
 
 > Note: the second token in `/plugin install <plugin>@<marketplace>` is the **marketplace name** (the `name` field in the marketplace's `marketplace.json`), NOT the GitHub repository slug. The README's [Install section](../README.md#60-second-quickstart) is the canonical place where the marketplace-name-vs-repo-slug distinction is documented; this `try:` block intentionally mirrors that exact form. If the exact `<plugin>@<marketplace>` syntax differs in your Claude Code version, the marketplace add line is the load-bearing part — you can then use the interactive `/plugin install` UI to pick the plugin from the just-added marketplace.
 


### PR DESCRIPTION
Closes #9

## Summary
- Add Plugin Metadata Resolution Procedure to `doctor.md` checks 7-10, reading `plugin.json` from the plugin cache to extract repository URL and version
- Compare installed plugin origins against `doctor.expected_origins` config for supply-chain verification
- Add `doctor.expected_origins` config key with canonical defaults for the four dependency plugins
- Add CI-parseable `PLUGIN_CHECK` verbose output lines for automated origin pinning

## Implementation notes
- Reusable procedure pattern (inputs: PMRP_GLOB, PMRP_SKILL, PMRP_OFFICIAL) avoids repeating metadata resolution logic across 4 checks — adding a 5th plugin is 3 lines
- Official Anthropic plugins (feature-dev) are identified via `claude-plugins-official/` cache path since they lack `repository` fields
- Output format aligned with existing doctor convention (`✅ <name>` / `⚠️  <name>: <reason>`)
- `-maxdepth 4` in `find` matches actual cache depth: `<marketplace>/<plugin>/<version>/.claude-plugin/plugin.json`

## Pre-PR review summary
- gate2 mode: advisor-only (no binary gate configured)
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: green via /ask
- review provider: copilot

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/9-feat-doctor-surface-skill-origin-urls-from-pl.gate1.md
- ~/.claude/cache/gh-issue-driven/9-feat-doctor-surface-skill-origin-urls-from-pl.gate2.md

🤖 Generated via /gh-issue-driven:ship
