### PR TITLE
feat(ship): add HITL confirmation gate on gate2 green verdict (#55)

### DIFF
--- a/commands/config.md
+++ b/commands/config.md
@@ -176,6 +176,7 @@ Users without kagura-memory installed can ignore this field — recall is skippe
       "/claude-c-suite:cto"
     ],
     "yellow_continue_requires_confirm": true,
+    "green_continue_requires_confirm": true,
     "run_tests_before_gate2": false
   },
   "review": {

--- a/commands/ship.md
+++ b/commands/ship.md
@@ -340,7 +340,7 @@ Invoke `AskUserQuestion`:
 
 When `lang != "en"`, produce the question text and option labels in the language specified by `lang`.
 
-This step also runs when `DRY_RUN` is `true` — the operator still sees the gate2 summary and confirms intent, even though step 11 (push) and step 12 (PR creation) will be skipped. This matches `start.md` step 18's behavior where the HITL fires regardless of dry-run.
+This step also runs when `DRY_RUN` is `true` — the operator still sees the gate2 summary and confirms intent, even though step 11 (push) and step 12 (PR creation) will be skipped.
 
 ### 10. Persist gate2 state and markdown
 

--- a/commands/ship.md
+++ b/commands/ship.md
@@ -311,9 +311,36 @@ If `ADVISOR_OUTS` is empty (no advisors configured or all skills unavailable), s
 
 ### 9. Verdict handling
 
-- **green** → continue to step 10.
+- **green** → if `gate2.green_continue_requires_confirm` is `true` (default), proceed to step 9a (which prints the summary and asks the operator). If `false`, continue silently to step 10.
 - **yellow** → print the per-reviewer summary table, then ask via AskUserQuestion: "Gate2 returned yellow. Continue with PR creation?" with options "Yes, ship it" / "No, abort". On abort, save state with `phase=gated` and exit cleanly.
 - **red** → if `FORCE` is true, log a loud warning and continue. Otherwise abort with the per-reviewer findings printed.
+
+#### 9a. HITL confirmation on green verdict
+
+This sub-step runs only when `GATE2_VERDICT` is `green` AND `gate2.green_continue_requires_confirm` is `true`.
+
+Print a short `Considerations:` block showing the gate2 per-reviewer summary:
+
+```
+Considerations:
+  - Gate2: green
+  - <for each advisor in ADVISORS (config order):>
+      • <display_label>: <ADVISOR_VERDICTS[advisor]>
+  - <if AUDIT_VERDICT != "skipped": "audit: <AUDIT_VERDICT>">
+```
+
+When `lang != "en"`, produce the Considerations block in the language specified by `lang`.
+
+Invoke `AskUserQuestion`:
+
+- **Question**: `Gate2 is green. Proceed to PR creation?`
+- **Option 1 — "Yes, ship it"**: continue to step 10.
+- **Option 2 — "No, abort"**: save state with `phase=gated` and exit cleanly.
+- **Option 3 — "I have feedback"**: print a one-line acknowledgement inviting the operator to type their note (`Got it — what's on your mind?`). Wait for the operator's next message. Respond to it conversationally — do not auto-launch any skill. After responding, re-present the same AskUserQuestion (options 1-3) so the operator makes an explicit Yes/No choice. Do NOT auto-continue to step 10 based on the model's judgment of whether the feedback was "minor" — the operator always gets the final say.
+
+When `lang != "en"`, produce the question text and option labels in the language specified by `lang`.
+
+This step also runs when `DRY_RUN` is `true` — the operator still sees the gate2 summary and confirms intent, even though step 11 (push) and step 12 (PR creation) will be skipped. This matches `start.md` step 18's behavior where the HITL fires regardless of dry-run.
 
 ### 10. Persist gate2 state and markdown
 


### PR DESCRIPTION
Closes #55

## Summary
- Add HITL confirmation gate on gate2 green verdict in ship.md step 9
- New config option `gate2.green_continue_requires_confirm` (default `true`)
- When true, green path pauses with 3-option AskUserQuestion before push+PR
- Feedback path re-presents the question after response (no auto-continue on model judgment)

## Implementation notes
- ship.md step 9: green bullet updated to check config and dispatch to step 9a
- ship.md step 9a: new sub-step with Considerations block + AskUserQuestion (Yes/No/Feedback)
- config.md: added `gate2.green_continue_requires_confirm: true` to built-in defaults alongside existing `gate2.yellow_continue_requires_confirm`
- Fires on DRY_RUN too (matches start.md step 18 pattern)
- Pattern follows start.md step 18 (gate1 green HITL) and propose.md step 11 (pre-filing HITL)

## Pre-PR review summary
- gate2 mode: advisor-only (no binary gate configured)
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: green via /ask
- review provider: copilot

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/55-feat-feat-ship-add-hitl-confirmation-gate-on-g.gate1.md
- ~/.claude/cache/gh-issue-driven/55-feat-feat-ship-add-hitl-confirmation-gate-on-g.gate2.md

🤖 Generated via /gh-issue-driven:ship
