### PR TITLE
feat(start): add --worktree flag with .gitignore and doctor wiring (#62)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,8 @@ venv/
 *.tmp
 *.bak
 
+# Git worktrees created by `/gh-issue-driven:start --worktree` (local convenience only)
+/.worktrees/
+
 # Logs
 *.log

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,7 +77,7 @@ A few load-bearing principles that shape what gets accepted into `commands/`:
 
 - **Three phases, not four.** The plugin has exactly three user-facing phases: `/start` → `/ship` → `/tag`. When a feature adds a new capability to a phase, it lands as a **flag on the existing command**, not a new top-level command. For example, `/gh-issue-driven:start --worktree` (issue #62) is a flag, not a hypothetical `/gh-issue-driven:worktree` command — a new top-level command would fragment the mental model and break the `start → ship → tag` progression. New commands are reserved for genuinely new phases (like `/propose` and `/review`, which each represent a distinct phase of work).
 - **Plugin integration is opt-in, never required.** Integrations with other plugins (`superpowers`, `feature-dev`, `claude-c-suite`, `kagura-memory`) degrade to a safe fallback when the plugin is missing. Hard dependencies are limited to `gh`, `git`, `jq`, and (optionally) `python3`.
-- **Presence checks belong in one place.** If two commands need to answer the same "is plugin X installed?" question, they use the **same probe method** (see `commands/start.md` step 13b and `commands/doctor.md` step 11 for the `superpowers` example — both use `ls ~/.claude/plugins/cache/superpowers*`). Drift here silently produces inconsistent behavior.
+- **Presence checks belong in one place.** If two commands need to answer the same "is plugin X installed?" question, they use the **same probe method** (see `commands/start.md` step 13b and `commands/doctor.md` step 11 for the `superpowers` example — both use `ls -d ~/.claude/plugins/cache/superpowers*`). Drift here silently produces inconsistent behavior.
 
 ## Releasing
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,6 +71,14 @@ The reviewer skills (`/claude-c-suite:*`, `/claude-phd-panel:*`) are advisory by
 
 If you maintain a c-suite or phd-panel skill, **adding the Verdict line is the single highest-leverage change** for `gh-issue-driven` integration.
 
+## Design principles
+
+A few load-bearing principles that shape what gets accepted into `commands/`:
+
+- **Three phases, not four.** The plugin has exactly three user-facing phases: `/start` → `/ship` → `/tag`. When a feature adds a new capability to a phase, it lands as a **flag on the existing command**, not a new top-level command. For example, `/gh-issue-driven:start --worktree` (issue #62) is a flag, not a hypothetical `/gh-issue-driven:worktree` command — a new top-level command would fragment the mental model and break the `start → ship → tag` progression. New commands are reserved for genuinely new phases (like `/propose` and `/review`, which each represent a distinct phase of work).
+- **Plugin integration is opt-in, never required.** Integrations with other plugins (`superpowers`, `feature-dev`, `claude-c-suite`, `kagura-memory`) degrade to a safe fallback when the plugin is missing. Hard dependencies are limited to `gh`, `git`, `jq`, and (optionally) `python3`.
+- **Presence checks belong in one place.** If two commands need to answer the same "is plugin X installed?" question, they use the **same probe method** (see `commands/start.md` step 13b and `commands/doctor.md` step 11 for the `superpowers` example — both use `ls ~/.claude/plugins/cache/superpowers*`). Drift here silently produces inconsistent behavior.
+
 ## Releasing
 
 Releases have two parts: the **release checklist** (dogfooding gate, below) and the mechanical tag-and-push ceremony (`/gh-issue-driven:tag` automates steps 1–5).

--- a/README.ja.md
+++ b/README.ja.md
@@ -183,7 +183,7 @@ PR が default branch にマージされ、milestone の準備が整った後に
 
 ## 並行開発 (`--worktree`)
 
-`/gh-issue-driven:start --worktree <issue>` は、in-place で checkout する代わりに、新しい feature branch を別の [git worktree](https://git-scm.com/docs/git-worktree) の中に作成します。これによりメインの作業ディレクトリを `main`(または別の feature branch)のままにしつつ、新しい branch での実装を別ディレクトリで並行して進められます。
+`/gh-issue-driven:start <issue> --worktree` は、in-place で checkout する代わりに、新しい feature branch を別の [git worktree](https://git-scm.com/docs/git-worktree) の中に作成します。これによりメインの作業ディレクトリを `main`(または別の feature branch)のままにしつつ、新しい branch での実装を別ディレクトリで並行して進められます。(`start` は issue identifier を先に解釈し、続くトークンを flag として解釈するので、`--worktree` は必ず issue の *後* に置きます。)
 
 ### 1 つのフラグに 2 系統のパス
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -181,6 +181,35 @@ PR が default branch にマージされ、milestone の準備が整った後に
 
 ---
 
+## 並行開発 (`--worktree`)
+
+`/gh-issue-driven:start --worktree <issue>` は、in-place で checkout する代わりに、新しい feature branch を別の [git worktree](https://git-scm.com/docs/git-worktree) の中に作成します。これによりメインの作業ディレクトリを `main`(または別の feature branch)のままにしつつ、新しい branch での実装を別ディレクトリで並行して進められます。
+
+### 1 つのフラグに 2 系統のパス
+
+- **`superpowers` プラグインが入っている場合**: `superpowers:using-git-worktrees` に委譲されます。smart directory selection によって、通常はリポジトリ外の sibling path に worktree が配置されます。
+- **入っていない場合**: フォールバックとしてリポジトリ内の `.worktrees/<branch>` に作成します。このディレクトリは `/.worktrees/` エントリで gitignore 済み(`/gh-issue-driven:doctor --fix` で自動追記されます)。`--branch=<override>` と併用すると `.worktrees/<override>` に配置されます。
+
+どちらのパスでも、`start` の recap に `cd <worktree-path>` のヒントが表示されるので、次のシェルプロンプトで正しい作業ディレクトリに移動できます。
+
+### ライフサイクル ― merge 後の後片付け
+
+PR が merge されても worktree は自動削除されません。merge して `main` を pull したあと、以下を実行してください:
+
+```bash
+git worktree remove <worktree-path>
+git worktree prune   # 古い登録情報の掃除
+```
+
+先にディレクトリを `rm -rf` してしまった場合(推奨しません)は、`git worktree prune` だけで dangling 登録を解消できます。
+
+### `--worktree` を使うか、superpowers を直接呼ぶか
+
+- **`start --worktree` を使う**: このプラグインの 3 フェーズフロー (`start → ship → tag`) に worktree を紐付けたいとき。branch 名・state file・gate1 サマリが全て新 branch 用に揃います。
+- **`superpowers:using-git-worktrees` を直接呼ぶ**: このプラグインとは無関係に worktree が欲しいとき (任意 branch のレビュー、実験など) — state file も gate1 review も走りません。
+
+---
+
 ## Copilot レビューループ
 
 `gh pr create` の後、`/gh-issue-driven:ship` はレビュアの add を発火し、polling loop に入る前に **HITL 確認ゲート** で立ち止まります(v0.3.0 以降):

--- a/README.ja.md
+++ b/README.ja.md
@@ -188,7 +188,7 @@ PR が default branch にマージされ、milestone の準備が整った後に
 ### 1 つのフラグに 2 系統のパス
 
 - **`superpowers` プラグインが入っている場合**: `superpowers:using-git-worktrees` に委譲されます。smart directory selection によって、通常はリポジトリ外の sibling path に worktree が配置されます。
-- **入っていない場合**: フォールバックとしてリポジトリ内の `.worktrees/<branch>` に作成します。このディレクトリは `/.worktrees/` エントリで gitignore 済み(`/gh-issue-driven:doctor --fix` で自動追記されます)。`--branch=<override>` と併用すると `.worktrees/<override>` に配置されます。
+- **入っていない場合**: フォールバックとしてリポジトリ内の `.worktrees/<branch>` に作成します。このディレクトリは `/.worktrees/` エントリで gitignore しておく想定で、`/gh-issue-driven:doctor fix` を実行すると `/.worktrees/` 追記用の `try:` コマンドが表示されます(doctor 自身は read-only でファイル編集は一切しないため、オペレータが手動で実行します)。`--branch=<override>` と併用すると `.worktrees/<override>` に配置されます。
 
 どちらのパスでも、`start` の recap に `cd <worktree-path>` のヒントが表示されるので、次のシェルプロンプトで正しい作業ディレクトリに移動できます。
 

--- a/README.md
+++ b/README.md
@@ -182,6 +182,35 @@ If you maintain a `claude-c-suite` or `claude-phd-panel` reviewer skill, emittin
 
 ---
 
+## Parallel development (`--worktree`)
+
+`/gh-issue-driven:start --worktree <issue>` creates the feature branch inside a separate [git worktree](https://git-scm.com/docs/git-worktree) instead of checking out in-place. This lets you keep the main working tree on `main` (or on another feature branch) while implementation proceeds in the new one.
+
+### Two paths, same flag
+
+- **With `superpowers` plugin installed**: delegates to `superpowers:using-git-worktrees`, which performs smart directory selection outside the repo (typically a sibling path).
+- **Without `superpowers`**: fallback creates `.worktrees/<branch>` inside the repo. The directory is gitignored via `/.worktrees/` (entry added for you if you run `/gh-issue-driven:doctor --fix`). When combined with `--branch=<override>`, the fallback places the worktree at `.worktrees/<override>`.
+
+In both cases, the `start` recap prints a `cd <worktree-path>` hint so you land in the new worktree on your next shell prompt.
+
+### Lifecycle — clean up after merge
+
+A worktree is not automatically removed when the PR is merged. After merging and pulling `main`, run:
+
+```bash
+git worktree remove <worktree-path>
+git worktree prune   # cleans up any stale registrations
+```
+
+If you manually `rm -rf` the directory first (don't), `git worktree prune` alone is enough to clear the dangling registration.
+
+### When to use `--worktree` vs calling superpowers directly
+
+- **Use `start --worktree`** when you want the worktree tied to this plugin's 3-phase flow (`start → ship → tag`) — branch name, state file, and gate1 summary all land in the expected places for the new branch.
+- **Invoke `superpowers:using-git-worktrees` directly** when you want a worktree for something outside this plugin (reviewing an arbitrary branch, experimenting, etc.) — no state file, no gate1 review.
+
+---
+
 ## Copilot review loop
 
 After `gh pr create`, `/gh-issue-driven:ship` fires the reviewer add and pauses at a **HITL confirmation gate** (since v0.3.0) before entering the polling loop:

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ If you maintain a `claude-c-suite` or `claude-phd-panel` reviewer skill, emittin
 ### Two paths, same flag
 
 - **With `superpowers` plugin installed**: delegates to `superpowers:using-git-worktrees`, which performs smart directory selection outside the repo (typically a sibling path).
-- **Without `superpowers`**: fallback creates `.worktrees/<branch>` inside the repo. The directory is gitignored via `/.worktrees/` (entry added for you if you run `/gh-issue-driven:doctor --fix`). When combined with `--branch=<override>`, the fallback places the worktree at `.worktrees/<override>`.
+- **Without `superpowers`**: fallback creates `.worktrees/<branch>` inside the repo. The directory should be gitignored via `/.worktrees/`; running `/gh-issue-driven:doctor fix` prints an idempotent `try:` command to append that entry, which the operator runs manually (doctor itself is read-only and never edits files). When combined with `--branch=<override>`, the fallback places the worktree at `.worktrees/<override>`.
 
 In both cases, the `start` recap prints a `cd <worktree-path>` hint so you land in the new worktree on your next shell prompt.
 

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ If you maintain a `claude-c-suite` or `claude-phd-panel` reviewer skill, emittin
 
 ## Parallel development (`--worktree`)
 
-`/gh-issue-driven:start --worktree <issue>` creates the feature branch inside a separate [git worktree](https://git-scm.com/docs/git-worktree) instead of checking out in-place. This lets you keep the main working tree on `main` (or on another feature branch) while implementation proceeds in the new one.
+`/gh-issue-driven:start <issue> --worktree` creates the feature branch inside a separate [git worktree](https://git-scm.com/docs/git-worktree) instead of checking out in-place. This lets you keep the main working tree on `main` (or on another feature branch) while implementation proceeds in the new one. (Flag order matters — `start` parses issue identifiers first, then flags, so `--worktree` comes *after* the issue.)
 
 ### Two paths, same flag
 

--- a/commands/doctor.md
+++ b/commands/doctor.md
@@ -16,7 +16,7 @@ What stays English regardless of `lang`:
 - The cache file's JSON content and the state schema field names
 - The `try:` hint commands themselves (e.g. `apt install jq`, `/plugin install ...`) — only the surrounding prose is localized
 
-The Configuration file health check at step 11 reads `~/.claude/gh-issue-driven-config.json` as part of its informational scan; doctor's own `lang` read in this section is just-in-time, separate from step 11. (Same just-in-time pattern as the Copilot setup section's read of `copilot.skip_setup_prompt`.)
+The Configuration file health check at step 13 reads `~/.claude/gh-issue-driven-config.json` as part of its informational scan; doctor's own `lang` read in this section is just-in-time, separate from step 13. (Same just-in-time pattern as the Copilot setup section's read of `copilot.skip_setup_prompt`.)
 
 ## Trust boundary
 
@@ -425,16 +425,23 @@ CI scripts can parse with `grep '^PLUGIN_CHECK'` and fail on `status=unexpected`
     This is informational only — never `⚠️` or `❌`. The file is optional but recommended for repos that use the Copilot review loop (`/gh-issue-driven:ship` step 14).
 
 18. **Worktree gitignore entry** (informational — only relevant when `/gh-issue-driven:start --worktree` is used without `superpowers` installed)
-    ```bash
-    grep -qE '^/?\.worktrees/?$' .gitignore 2>/dev/null
-    ```
-    - Match → `✅ worktree gitignore: /.worktrees/ entry present in .gitignore`
-    - No match AND `.gitignore` exists → `ℹ️  worktree gitignore: .gitignore has no /.worktrees/ entry — add one if you plan to use /gh-issue-driven:start --worktree and superpowers is not installed (the fallback path creates worktrees under .worktrees/<branch> inside this repo and they should not be committed)`
-    - `.gitignore` absent → `ℹ️  worktree gitignore: .gitignore not present — skipped`
 
-    This is informational only, never `⚠️` or `❌`. The entry only matters for the superpowers-less fallback in `start.md` step 13b; with superpowers installed, worktrees typically live outside the repo (smart directory selection) and the entry is moot. When `fix` flag is set AND the entry is missing AND `.gitignore` exists, append a single `try:` line:
+    Resolve the repo root first so the check works regardless of which subdirectory doctor is invoked from — `.gitignore` is anchored to the repo root, so reading the cwd-relative file would false-negative for any invocation outside the top level.
+
+    ```bash
+    REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+    if [ -n "$REPO_ROOT" ] && [ -f "$REPO_ROOT/.gitignore" ]; then
+      grep -qE '^/?\.worktrees/?$' "$REPO_ROOT/.gitignore"
+    fi
     ```
-       try: printf '%s\n' '' '# Git worktrees from /gh-issue-driven:start --worktree (local-only)' '/.worktrees/' >> .gitignore
+
+    - Match → `✅ worktree gitignore: /.worktrees/ entry present in repo-root .gitignore`
+    - No match AND repo-root `.gitignore` exists → `ℹ️  worktree gitignore: .gitignore has no /.worktrees/ entry — add one if you plan to use /gh-issue-driven:start --worktree and superpowers is not installed (the fallback path creates worktrees under .worktrees/<branch> inside this repo and they should not be committed)`
+    - `.gitignore` absent at the repo root → `ℹ️  worktree gitignore: repo-root .gitignore not present — skipped`
+
+    This is informational only, never `⚠️` or `❌`. The entry only matters for the superpowers-less fallback in `start.md` step 13b; with superpowers installed, worktrees typically live outside the repo (smart directory selection) and the entry is moot. When `fix` flag is set AND the entry is missing AND repo-root `.gitignore` exists, append a single `try:` line:
+    ```
+       try: printf '%s\n' '' '# Git worktrees from /gh-issue-driven:start --worktree (local-only)' '/.worktrees/' >> "$(git rev-parse --show-toplevel)/.gitignore"
     ```
 
 ### Final summary

--- a/commands/doctor.md
+++ b/commands/doctor.md
@@ -361,36 +361,50 @@ CI scripts can parse with `grep '^PLUGIN_CHECK'` and fail on `status=unexpected`
      ```
      (Available from the Claude Code official marketplace — no marketplace add needed.)
 
+11. **Worktree plugin: `superpowers`** (optional — enhances `/gh-issue-driven:start --worktree` with smart directory selection)
+   - Probe via plugin cache glob: `~/.claude/plugins/cache/superpowers*`. `start.md` step 13b uses the **identical glob probe** (`ls -d ~/.claude/plugins/cache/superpowers*`) so the two commands answer "is superpowers installed?" the same way — they MUST NOT drift. When changing the glob here, update `commands/start.md` step 13b in the same commit.
+   - Run the Plugin Metadata Resolution Procedure with:
+     - `PMRP_GLOB=superpowers*`
+     - `PMRP_SKILL=superpowers`
+     - `PMRP_OFFICIAL=false`
+   - If `PLUGIN_FOUND=false`: emit `⚠️  superpowers: not installed — /gh-issue-driven:start --worktree will fall back to direct `git worktree add .worktrees/<branch>`, which still works (no hard requirement)`.
+   - Otherwise: emit the status line per the procedure's output format.
+   - When `fix` flag is set AND missing, append a 2-line `try:` block:
+     ```
+        try: /plugin marketplace add obra/superpowers-marketplace
+             /plugin install superpowers@superpowers-marketplace
+     ```
+
 > Note: the second token in `/plugin install <plugin>@<marketplace>` is the **marketplace name** (the `name` field in the marketplace's `marketplace.json`), NOT the GitHub repository slug. The README's [Install section](../README.md#60-second-quickstart) is the canonical place where the marketplace-name-vs-repo-slug distinction is documented; this `try:` block intentionally mirrors that exact form. If the exact `<plugin>@<marketplace>` syntax differs in your Claude Code version, the marketplace add line is the load-bearing part — you can then use the interactive `/plugin install` UI to pick the plugin from the just-added marketplace.
 
 ### Informational checks
 
-11. **Working tree clean**
+12. **Working tree clean**
     ```bash
     test -z "$(git status --porcelain)"
     ```
     Warn if dirty (but `start` would refuse anyway — this is an early heads-up).
 
-12. **Configuration file**
+13. **Configuration file**
     ```bash
     test -f ~/.claude/gh-issue-driven-config.json && jq empty ~/.claude/gh-issue-driven-config.json
     ```
     - Missing → informational, defaults will be used. Hint: `/gh-issue-driven:config init`.
     - Present but unparseable → warn with the `jq` error.
 
-13. **gh API scope check**
+14. **gh API scope check**
     ```bash
     gh api user --jq .login
     ```
     Just to confirm the auth has API access.
 
-14. **Copilot reviewer reachability** (informational, may be unsupported on some plans)
+15. **Copilot reviewer reachability** (informational, may be unsupported on some plans)
     ```bash
     gh api repos/:owner/:repo/collaborators 2>/dev/null | grep -q copilot
     ```
     Print `✅` / `⚠️ Copilot reviewer not detected — may still work via @copilot mention`.
 
-15. **Stale state files**
+16. **Stale state files**
     List `~/.claude/cache/gh-issue-driven/*.json` and check whether the corresponding branch (decoded from filename) still exists locally:
     ```bash
     git show-ref --verify --quiet refs/heads/<branch>
@@ -401,7 +415,7 @@ CI scripts can parse with `grep '^PLUGIN_CHECK'` and fail on `status=unexpected`
     ```
     Never auto-delete.
 
-16. **Copilot review instructions**
+17. **Copilot review instructions**
     ```bash
     test -f .github/copilot-instructions.md
     ```
@@ -409,6 +423,19 @@ CI scripts can parse with `grep '^PLUGIN_CHECK'` and fail on `status=unexpected`
     - Absent → `ℹ️  copilot-instructions: .github/copilot-instructions.md not found — Copilot review quality improves with project-specific instructions. See: https://docs.github.com/en/copilot/how-tos/use-copilot-agents/request-a-code-review/use-code-review`
 
     This is informational only — never `⚠️` or `❌`. The file is optional but recommended for repos that use the Copilot review loop (`/gh-issue-driven:ship` step 14).
+
+18. **Worktree gitignore entry** (informational — only relevant when `/gh-issue-driven:start --worktree` is used without `superpowers` installed)
+    ```bash
+    grep -qE '^/?\.worktrees/?$' .gitignore 2>/dev/null
+    ```
+    - Match → `✅ worktree gitignore: /.worktrees/ entry present in .gitignore`
+    - No match AND `.gitignore` exists → `ℹ️  worktree gitignore: .gitignore has no /.worktrees/ entry — add one if you plan to use /gh-issue-driven:start --worktree and superpowers is not installed (the fallback path creates worktrees under .worktrees/<branch> inside this repo and they should not be committed)`
+    - `.gitignore` absent → `ℹ️  worktree gitignore: .gitignore not present — skipped`
+
+    This is informational only, never `⚠️` or `❌`. The entry only matters for the superpowers-less fallback in `start.md` step 13b; with superpowers installed, worktrees typically live outside the repo (smart directory selection) and the entry is moot. When `fix` flag is set AND the entry is missing AND `.gitignore` exists, append a single `try:` line:
+    ```
+       try: printf '%s\n' '' '# Git worktrees from /gh-issue-driven:start --worktree (local-only)' '/.worktrees/' >> .gitignore
+    ```
 
 ### Final summary
 

--- a/commands/doctor.md
+++ b/commands/doctor.md
@@ -96,7 +96,7 @@ The 7-day TTL is a fixed const in this command, not a config knob — re-confirm
 
 #### Check logic
 
-Load the effective configuration just-in-time for this section: read `~/.claude/gh-issue-driven-config.json` if it exists and parses cleanly, then deep-merge user values over the built-in defaults documented in `/gh-issue-driven:config`. If the file is absent or unparseable, use the defaults silently — the broader Configuration file health check at step 11 (informational) will surface the parse error separately. The just-in-time load is necessary because this Copilot setup section runs in the Required-checks zone, **before** step 11; the two reads do not conflict because step 11 is informational and never blocks.
+Load the effective configuration just-in-time for this section: read `~/.claude/gh-issue-driven-config.json` if it exists and parses cleanly, then deep-merge user values over the built-in defaults documented in `/gh-issue-driven:config`. If the file is absent or unparseable, use the defaults silently — the broader Configuration file health check at step 13 (informational) will surface the parse error separately. The just-in-time load is necessary because this Copilot setup section runs in the Required-checks zone, **before** step 13; the two reads do not conflict because step 13 is informational and never blocks.
 
 From the merged config, read `copilot.skip_setup_prompt` (default `false`). If true, print one line `✅ Copilot setup: prompt skipped (copilot.skip_setup_prompt=true)` and skip to the gh version check at the bottom of this section.
 

--- a/commands/doctor.md
+++ b/commands/doctor.md
@@ -426,22 +426,26 @@ CI scripts can parse with `grep '^PLUGIN_CHECK'` and fail on `status=unexpected`
 
 18. **Worktree gitignore entry** (informational — only relevant when `/gh-issue-driven:start --worktree` is used without `superpowers` installed)
 
-    Resolve the repo root first so the check works regardless of which subdirectory doctor is invoked from — `.gitignore` is anchored to the repo root, so reading the cwd-relative file would false-negative for any invocation outside the top level.
+    Resolve the repo root first so the check works regardless of which subdirectory doctor is invoked from — `.gitignore` is anchored to the repo root, so reading the cwd-relative file would false-negative for any invocation outside the top level. Three outcomes must be distinguishable in the caller (match, missing, absent), so an `if / elif / else` with an explicit status variable is clearer than relying on the exit status of a nested `grep` inside an `if`:
 
     ```bash
     REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
-    if [ -n "$REPO_ROOT" ] && [ -f "$REPO_ROOT/.gitignore" ]; then
-      grep -qE '^/?\.worktrees/?$' "$REPO_ROOT/.gitignore"
+    if [ -z "$REPO_ROOT" ] || [ ! -f "$REPO_ROOT/.gitignore" ]; then
+      WORKTREE_GITIGNORE_STATUS=absent         # not in a git repo, or no repo-root .gitignore
+    elif grep -qE '^/?\.worktrees/?$' "$REPO_ROOT/.gitignore"; then
+      WORKTREE_GITIGNORE_STATUS=match          # entry present
+    else
+      WORKTREE_GITIGNORE_STATUS=missing        # .gitignore exists but no /.worktrees/ entry
     fi
     ```
 
-    - Match → `✅ worktree gitignore: /.worktrees/ entry present in repo-root .gitignore`
-    - No match AND repo-root `.gitignore` exists → `ℹ️  worktree gitignore: .gitignore has no /.worktrees/ entry — add one if you plan to use /gh-issue-driven:start --worktree and superpowers is not installed (the fallback path creates worktrees under .worktrees/<branch> inside this repo and they should not be committed)`
-    - `.gitignore` absent at the repo root → `ℹ️  worktree gitignore: repo-root .gitignore not present — skipped`
+    - `match` → `✅ worktree gitignore: /.worktrees/ entry present in repo-root .gitignore`
+    - `missing` → `ℹ️  worktree gitignore: .gitignore has no /.worktrees/ entry — add one if you plan to use /gh-issue-driven:start --worktree and superpowers is not installed (the fallback path creates worktrees under .worktrees/<branch> inside this repo and they should not be committed)`
+    - `absent` → `ℹ️  worktree gitignore: repo-root .gitignore not present — skipped`
 
-    This is informational only, never `⚠️` or `❌`. The entry only matters for the superpowers-less fallback in `start.md` step 13b; with superpowers installed, worktrees typically live outside the repo (smart directory selection) and the entry is moot. When `fix` flag is set AND the entry is missing AND repo-root `.gitignore` exists, append a single `try:` line. The suggested command is **idempotent** — it grep-guards against existing entries before appending, so re-running it (or running it after the grep check false-negatives on a formatting variant) is safe:
+    This is informational only, never `⚠️` or `❌`. The entry only matters for the superpowers-less fallback in `start.md` step 13b; with superpowers installed, worktrees typically live outside the repo (smart directory selection) and the entry is moot. When `fix` flag is set AND `WORKTREE_GITIGNORE_STATUS=missing`, append a single `try:` line. The suggested command is **idempotent** — it strips comment lines and then uses the **same anchored pattern as the check above** to grep-guard, so re-running it is safe and the guard cannot false-positive on comment lines or substring matches in unrelated paths (e.g. `foo/.worktrees/bar`):
     ```
-       try: gitignore="$(git rev-parse --show-toplevel)/.gitignore" && grep -qxE '/?\.worktrees/?' "$gitignore" 2>/dev/null || printf '%s\n' '' '# Git worktrees from /gh-issue-driven:start --worktree (local-only)' '/.worktrees/' >> "$gitignore"
+       try: gitignore="$(git rev-parse --show-toplevel)/.gitignore" && grep -vE '^[[:space:]]*#' "$gitignore" 2>/dev/null | grep -qxE '^/?\.worktrees/?$' || printf '%s\n' '' '# Git worktrees from /gh-issue-driven:start --worktree (local-only)' '/.worktrees/' >> "$gitignore"
     ```
 
 ### Final summary

--- a/commands/doctor.md
+++ b/commands/doctor.md
@@ -439,9 +439,9 @@ CI scripts can parse with `grep '^PLUGIN_CHECK'` and fail on `status=unexpected`
     - No match AND repo-root `.gitignore` exists → `ℹ️  worktree gitignore: .gitignore has no /.worktrees/ entry — add one if you plan to use /gh-issue-driven:start --worktree and superpowers is not installed (the fallback path creates worktrees under .worktrees/<branch> inside this repo and they should not be committed)`
     - `.gitignore` absent at the repo root → `ℹ️  worktree gitignore: repo-root .gitignore not present — skipped`
 
-    This is informational only, never `⚠️` or `❌`. The entry only matters for the superpowers-less fallback in `start.md` step 13b; with superpowers installed, worktrees typically live outside the repo (smart directory selection) and the entry is moot. When `fix` flag is set AND the entry is missing AND repo-root `.gitignore` exists, append a single `try:` line:
+    This is informational only, never `⚠️` or `❌`. The entry only matters for the superpowers-less fallback in `start.md` step 13b; with superpowers installed, worktrees typically live outside the repo (smart directory selection) and the entry is moot. When `fix` flag is set AND the entry is missing AND repo-root `.gitignore` exists, append a single `try:` line. The suggested command is **idempotent** — it grep-guards against existing entries before appending, so re-running it (or running it after the grep check false-negatives on a formatting variant) is safe:
     ```
-       try: printf '%s\n' '' '# Git worktrees from /gh-issue-driven:start --worktree (local-only)' '/.worktrees/' >> "$(git rev-parse --show-toplevel)/.gitignore"
+       try: gitignore="$(git rev-parse --show-toplevel)/.gitignore" && grep -qxE '/?\.worktrees/?' "$gitignore" 2>/dev/null || printf '%s\n' '' '# Git worktrees from /gh-issue-driven:start --worktree (local-only)' '/.worktrees/' >> "$gitignore"
     ```
 
 ### Final summary

--- a/commands/doctor.md
+++ b/commands/doctor.md
@@ -367,7 +367,7 @@ CI scripts can parse with `grep '^PLUGIN_CHECK'` and fail on `status=unexpected`
      - `PMRP_GLOB=superpowers*`
      - `PMRP_SKILL=superpowers`
      - `PMRP_OFFICIAL=false`
-   - If `PLUGIN_FOUND=false`: emit `⚠️  superpowers: not installed — /gh-issue-driven:start --worktree will fall back to direct `git worktree add .worktrees/<branch>`, which still works (no hard requirement)`.
+   - If `PLUGIN_FOUND=false`: emit ⚠️  `superpowers: not installed — /gh-issue-driven:start --worktree will fall back to direct git worktree add .worktrees/<branch>, which still works (no hard requirement)`.
    - Otherwise: emit the status line per the procedure's output format.
    - When `fix` flag is set AND missing, append a 2-line `try:` block:
      ```

--- a/commands/start.md
+++ b/commands/start.md
@@ -697,7 +697,7 @@ Write `~/.claude/cache/gh-issue-driven/<branch>.json` using a temp file + atomic
   "branch": "<branch>",
   "branch_type": "<type>",
   "is_batch": <IS_BATCH>,
-  "worktree_path": "<WORKTREE_PATH or null>",
+  "worktree_path": <WORKTREE_PATH or null>,
   "started_at": "<UTC ISO-8601>",
   "phase": "designed",
   "gate1": {
@@ -718,7 +718,7 @@ Schema notes:
 - **`issues` array**: contains all issues in input order. Each entry has `number`, `title`, `url`, and `labels`.
 - **`issue_number`, `issue_title`, `issue_url`**: v1-compatible aliases pointing to `issues[0]` (the primary issue). These fields ensure that `ship.md`, `status.md`, and any v1-era state readers continue to work without modification until they adopt the `issues` array.
 - **`is_batch`**: `true` when `len(issues) > 1`, `false` otherwise. Allows downstream commands to branch on batch mode without counting the array.
-- **`worktree_path`**: set from step 13b when `--worktree` was used (either the path superpowers returned, or the `.worktrees/<branch>` fallback). `null` when `--worktree` was not used. Readers can use this to render the `cd` hint in `/gh-issue-driven:status` or post-mortem output without re-deriving the path.
+- **`worktree_path`**: set from step 13b when `--worktree` was used (either the path superpowers returned, or the `.worktrees/<branch>` fallback). Serialized as a JSON string when populated, or the unquoted JSON literal `null` when `--worktree` was not used — matching the convention of other nullable fields like `gate1.escalated_to`. Readers can use this to render the `cd` hint in `/gh-issue-driven:status` or post-mortem output without re-deriving the path.
 - **v1 state files** (created before this change) remain valid — they have `issue_number`/`issue_title` but no `issues` array and no `worktree_path`. Readers should check for `issues` first and fall back to the top-level aliases; absent `worktree_path` is equivalent to `null`.
 
 `<branch-flat>` is the branch name with `/` replaced by `-` so it works as a filename.

--- a/commands/start.md
+++ b/commands/start.md
@@ -599,31 +599,33 @@ This sub-step also runs when `DRY_RUN` is `true` — the operator still sees the
 
 Skip this step entirely if `DRY_RUN` is true.
 
-Bring the local default branch up to date in both sub-paths:
+Fetch the default branch first (both sub-paths need an up-to-date remote ref):
 
 ```bash
 DEFAULT_BRANCH=<from config>
 git fetch origin "$DEFAULT_BRANCH"
-git checkout "$DEFAULT_BRANCH"
-git pull --ff-only origin "$DEFAULT_BRANCH"
 ```
-
-If `git pull --ff-only` fails (your local default branch has diverged), abort with a clear instruction to reconcile manually. Do not auto-rebase, do not auto-merge.
 
 Then branch on `WORKTREE`:
 
 #### 13a. In-place branch (default — `WORKTREE=false`)
 
+Move the current working tree to the default branch, fast-forward, and branch from there:
+
 ```bash
+git checkout "$DEFAULT_BRANCH"
+git pull --ff-only origin "$DEFAULT_BRANCH"
 git checkout -b <branch>
 git rev-parse --abbrev-ref HEAD  # verify
 ```
+
+If `git pull --ff-only` fails (your local default branch has diverged), abort with a clear instruction to reconcile manually. Do not auto-rebase, do not auto-merge.
 
 Set `WORKTREE_PATH=null` (for the state file and recap). The operator continues working in the current working directory.
 
 #### 13b. Isolated worktree (`WORKTREE=true`)
 
-The goal is to create the new branch inside a separate working tree so the operator can keep the primary working directory on the default branch (or on another feature branch) while implementation proceeds in the new one.
+The goal is to create the new branch inside a separate working tree so the operator can keep the primary working directory on whatever branch they were on (including — crucially — a feature branch they weren't ready to leave). Base the new worktree off `origin/<DEFAULT_BRANCH>` (already fetched above) — **do not** `git checkout "$DEFAULT_BRANCH"` or run `git pull` in the current worktree, those would forcibly move the operator's primary directory onto the default branch and defeat the purpose of `--worktree`. Fast-forward of the local `<DEFAULT_BRANCH>` pointer is deferred to whenever the operator chooses to update it themselves (typically after merging this PR).
 
 **Probe for `superpowers` plugin** (same method as `commands/doctor.md`'s PMRP step 1 — `ls ~/.claude/plugins/cache/superpowers*` succeeds iff installed):
 
@@ -639,7 +641,7 @@ Then choose a path:
 
 - **`SUPERPOWERS_PRESENT=true` — delegate to superpowers**:
 
-  > **Invoke the `/superpowers:using-git-worktrees` skill via the Skill tool**, asking it to create a worktree for branch `<branch>` off `<DEFAULT_BRANCH>`. Wait for the skill to complete. Capture the resulting worktree path the skill reports (it performs its own smart directory selection and safety checks — the path may or may not be under `.worktrees/`).
+  > **Invoke the `/superpowers:using-git-worktrees` skill via the Skill tool**, asking it to create a worktree for branch `<branch>` off `origin/<DEFAULT_BRANCH>` (i.e. the remote-tracking ref, not the local `<DEFAULT_BRANCH>` which may be behind). Wait for the skill to complete. Capture the resulting worktree path the skill reports (it performs its own smart directory selection and safety checks — the path may or may not be under `.worktrees/`).
   >
   > Set `WORKTREE_PATH=<path the skill used>`.
 
@@ -670,7 +672,7 @@ Then choose a path:
     exit 6
   fi
   mkdir -p "$(dirname "$WORKTREE_PATH")"
-  git worktree add "$WORKTREE_PATH" -b "<branch>" "$DEFAULT_BRANCH"
+  git worktree add "$WORKTREE_PATH" -b "<branch>" "origin/$DEFAULT_BRANCH"
   ```
 
   `WORKTREE_PATH` is stored in the state file and rendered in the step 16 recap exactly as computed above — i.e. an absolute path under the repo root. The `cd <WORKTREE_PATH>` hint then works from any shell regardless of the operator's current directory. Abort cleanly with the structured error above rather than surfacing the raw `git worktree add` error — both failure modes (filesystem clash, stale registration) need to route the operator to the same recovery commands. Use `grep -qxF` so the comparison is a fixed-string exact match on the whole line, avoiding regex / substring false matches when another registered worktree path contains `WORKTREE_PATH` as a substring.

--- a/commands/start.md
+++ b/commands/start.md
@@ -94,7 +94,7 @@ Allow-list (canonical definition for `start.md` — all downstream steps inherit
 | Each `ISSUE_NUM` in `ISSUE_NUMS` | `^[1-9][0-9]{0,8}$` | Positive integer, max 9 digits |
 | `OWNER` | `^[a-zA-Z0-9._-]{1,39}$` | Safe shell allow-list for the parsed owner token |
 | `REPO` | `^[a-zA-Z0-9._-]{1,100}$` | Safe shell allow-list for the parsed repo token |
-| `BRANCH_OVERRIDE` (if set) | `^[a-zA-Z0-9._/-]{1,100}$` | Safe shell allow-list for operator-provided branch name |
+| `BRANCH_OVERRIDE` (if set) | `^[a-zA-Z0-9._/-]{1,100}$` **+** `git check-ref-format --branch` | Safe shell allow-list **plus** git's own ref-name rules (no `..`, no leading `.`, no `@{`, etc.) so `--branch=../foo` — which the regex alone permits — cannot escape `$REPO_ROOT/.worktrees/` in step 13b |
 
 Validation (run in a single Bash block immediately after step 1 normalizes all identifiers, before any later bash interpolation):
 
@@ -112,6 +112,13 @@ done
 [[ "$REPO"  =~ ^[a-zA-Z0-9._-]{1,100}$ ]]     || { echo "error: invalid repo — '$REPO' does not match ^[a-zA-Z0-9._-]{1,100}$"; exit 10; }
 if [ -n "${BRANCH_OVERRIDE:-}" ]; then
   [[ "$BRANCH_OVERRIDE" =~ ^[a-zA-Z0-9._/-]{1,100}$ ]] || { echo "error: invalid --branch value — '$BRANCH_OVERRIDE' does not match ^[a-zA-Z0-9._/-]{1,100}$"; exit 10; }
+  # git's own ref-name rules are stricter than the regex: no '..', no leading '.', no '@{', no
+  # trailing '/', etc. Running `git check-ref-format --branch` as a second gate rejects
+  # '--branch=../foo' (regex-permissive, path-traversal-unsafe) before it reaches step 13b's
+  # `WORKTREE_PATH="$REPO_ROOT/.worktrees/<branch>"` construction where a `..` segment would
+  # escape the gitignored `.worktrees/` root.
+  git check-ref-format --branch "$BRANCH_OVERRIDE" >/dev/null 2>&1 \
+    || { echo "error: '--branch=$BRANCH_OVERRIDE' fails git check-ref-format (e.g. contains '..', leading '.', '@{', or other forbidden ref-name chars)"; exit 10; }
 fi
 ```
 
@@ -774,7 +781,7 @@ Output exactly one block in this format:
 Issue   #<num> <title>
         <url>
 Branch  <branch>  (created from <default-branch>)
-<if WORKTREE=true:>
+<if WORKTREE=true AND NOT DRY_RUN:>
 Worktree <WORKTREE_PATH>
         → cd <WORKTREE_PATH> to work on this branch
 </if>
@@ -792,7 +799,7 @@ Issues  #<n1> <title1>
         #<n3> <title3>
         ...
 Branch  <branch>  (created from <default-branch>)
-<if WORKTREE=true:>
+<if WORKTREE=true AND NOT DRY_RUN:>
 Worktree <WORKTREE_PATH>
         → cd <WORKTREE_PATH> to work on this branch
 </if>
@@ -803,6 +810,8 @@ Memory  <k> related contexts found  (top: "<top summary>" score <score>)
 ```
 
 The `Worktree` line is printed verbatim from `WORKTREE_PATH` (set in step 13b). When `--worktree` is combined with `--branch=<override>`, `WORKTREE_PATH` already reflects the override (e.g. `.worktrees/<override>`), so the `cd` hint always matches reality. When `--worktree` is absent, both `WORKTREE_PATH` and this entire line block are omitted — the recap stays identical to the pre-`--worktree` output for non-worktree runs.
+
+**`DRY_RUN` + `--worktree` interaction**: step 13 (branch + worktree creation) is skipped when `DRY_RUN` is true, so `WORKTREE_PATH` is never assigned. The recap suppresses the `Worktree` block in that combined case — rendering the block would either claim a literal placeholder or invent a preview path the superpowers-delegation path would not necessarily pick. The `[DRY RUN]` banner plus the Branch line are enough to convey the preview intent; the operator re-runs without `dry-run` to get the actual worktree location.
 
 ### 17. Print implementation guidance
 

--- a/commands/start.md
+++ b/commands/start.md
@@ -639,18 +639,31 @@ Then choose a path:
 
 - **`SUPERPOWERS_PRESENT=true` — delegate to superpowers**:
 
-  > **Invoke the `superpowers:using-git-worktrees` skill via the Skill tool**, asking it to create a worktree for branch `<branch>` off `<DEFAULT_BRANCH>`. Wait for the skill to complete. Capture the resulting worktree path the skill reports (it performs its own smart directory selection and safety checks — the path may or may not be under `.worktrees/`).
+  > **Invoke the `/superpowers:using-git-worktrees` skill via the Skill tool**, asking it to create a worktree for branch `<branch>` off `<DEFAULT_BRANCH>`. Wait for the skill to complete. Capture the resulting worktree path the skill reports (it performs its own smart directory selection and safety checks — the path may or may not be under `.worktrees/`).
   >
   > Set `WORKTREE_PATH=<path the skill used>`.
 
+  The leading `/` on the skill name matches the repo's `Invoke the /plugin:command skill via the Skill tool` convention used by every other Skill invocation in this file (`/kagura-memory:session-start`, `/claude-c-suite:ask`, …) — see CONTRIBUTING.md for why this phrasing is load-bearing for reliable Skill-tool routing.
+
 - **`SUPERPOWERS_PRESENT=false` — direct fallback**: create the worktree under the repo-local `.worktrees/` convention (gitignored via `/.worktrees/`).
+
+  Two stale-state footguns exist and must both be detected before calling `git worktree add`:
+  1. The target directory already exists on disk (operator left a stale copy behind).
+  2. The directory was manually deleted but the worktree is still registered with git (no filesystem entry, but `git worktree add` will reject with "already registered"). Checking only `[ -e "$WORKTREE_PATH" ]` misses this — the registry must be queried explicitly.
 
   ```bash
   WORKTREE_PATH=".worktrees/<branch>"
-  if [ -e "$WORKTREE_PATH" ]; then
-    echo "error: '$WORKTREE_PATH' already exists — a stale worktree may be present."
-    echo "       Clean it up first, then re-run: git worktree remove '$WORKTREE_PATH' && git worktree prune"
-    echo "       If git reports the worktree is already registered but the directory was manually deleted,"
+  WORKTREE_ABS="$(pwd)/$WORKTREE_PATH"
+  STALE=""
+  [ -e "$WORKTREE_PATH" ] && STALE="directory exists on disk"
+  if [ -z "$STALE" ] && git worktree list --porcelain 2>/dev/null \
+       | awk '/^worktree /{print $2}' | grep -qxF "$WORKTREE_ABS"; then
+    STALE="still registered in git worktree list (directory missing on disk)"
+  fi
+  if [ -n "$STALE" ]; then
+    echo "error: '$WORKTREE_PATH' is in a stale state — $STALE."
+    echo "       Recover with: git worktree remove '$WORKTREE_PATH' && git worktree prune"
+    echo "       If only the registration is stale (directory already deleted),"
     echo "       'git worktree prune' alone is enough."
     exit 6
   fi
@@ -658,7 +671,7 @@ Then choose a path:
   git worktree add "$WORKTREE_PATH" -b "<branch>" "$DEFAULT_BRANCH"
   ```
 
-  Abort cleanly with the error above rather than surfacing the raw `git worktree add` error — this is the most common stale-state footgun for operators, and the error message needs to point directly at the recovery commands.
+  Abort cleanly with the structured error above rather than surfacing the raw `git worktree add` error — both failure modes (filesystem clash, stale registration) need to route the operator to the same recovery commands. Use `grep -qxF` so the comparison is a fixed-string exact match on the whole line, avoiding regex / substring false matches when another registered worktree path contains `WORKTREE_ABS` as a substring.
 
 In both sub-paths, the branch name (`<branch>`) is the same value computed in step 6 — it already accounts for `--branch=<override>`, so when both `--worktree` and `--branch=<override>` are set the worktree directory is `.worktrees/<override>` (fallback path) or whatever superpowers picked for that branch name (delegated path).
 

--- a/commands/start.md
+++ b/commands/start.md
@@ -654,31 +654,46 @@ Then choose a path:
 
   Anchor paths at the repo root (`git rev-parse --show-toplevel`) so `/start --worktree` behaves correctly regardless of which subdirectory the operator invoked it from. The repo-root `/.worktrees/` gitignore rule is root-anchored, so a worktree accidentally created at `<subdir>/.worktrees/<branch>` would NOT be ignored. Pinning to the repo root also keeps the stale-registration compare (which is against absolute paths from `git worktree list --porcelain`) correct.
 
-  Two stale-state footguns exist and must both be detected before calling `git worktree add`:
-  1. The target directory already exists on disk (operator left a stale copy behind).
-  2. The directory was manually deleted but the worktree is still registered with git (no filesystem entry, but `git worktree add` will reject with "already registered"). Checking only `[ -e "$WORKTREE_PATH" ]` misses this — the registry must be queried explicitly.
+  Three stale-state shapes exist and each needs a different recovery — probe both the filesystem and the registry independently (do NOT short-circuit: dir-on-disk and registry-registered are orthogonal), then dispatch the correct recovery message:
+
+  | Disk | Registered | Recovery |
+  |---|---|---|
+  | yes | yes | `git worktree remove '$WORKTREE_PATH' && git worktree prune` |
+  | yes | no  | Delete or rename the directory manually (`git worktree remove` would fail with "not a working tree"), then re-run |
+  | no  | yes | `git worktree prune` alone |
+  | no  | no  | No stale state — proceed to `git worktree add` |
 
   ```bash
   REPO_ROOT=$(git rev-parse --show-toplevel)
   WORKTREE_PATH="$REPO_ROOT/.worktrees/<branch>"   # absolute, anchored to the repo root
-  STALE=""
-  [ -e "$WORKTREE_PATH" ] && STALE="directory exists on disk"
-  if [ -z "$STALE" ] && git worktree list --porcelain 2>/dev/null \
+  ON_DISK=""
+  REGISTERED=""
+  [ -e "$WORKTREE_PATH" ] && ON_DISK="yes"
+  if git worktree list --porcelain 2>/dev/null \
        | sed -n 's/^worktree //p' | grep -qxF "$WORKTREE_PATH"; then
-    STALE="still registered in git worktree list (directory missing on disk)"
+    REGISTERED="yes"
   fi
-  if [ -n "$STALE" ]; then
-    echo "error: '$WORKTREE_PATH' is in a stale state — $STALE."
+
+  if [ -n "$ON_DISK" ] && [ -n "$REGISTERED" ]; then
+    echo "error: '$WORKTREE_PATH' is already an active worktree (directory AND registration)."
     echo "       Recover with: git worktree remove '$WORKTREE_PATH' && git worktree prune"
-    echo "       If only the registration is stale (directory already deleted),"
-    echo "       'git worktree prune' alone is enough."
+    exit 6
+  elif [ -n "$ON_DISK" ]; then
+    echo "error: '$WORKTREE_PATH' exists on disk but is NOT registered as a worktree."
+    echo "       Do NOT run 'git worktree remove' — it will fail with 'not a working tree'."
+    echo "       Delete or rename the directory manually and re-run, e.g.:"
+    echo "         rm -rf '$WORKTREE_PATH'    # only if the contents are safe to drop"
+    exit 6
+  elif [ -n "$REGISTERED" ]; then
+    echo "error: '$WORKTREE_PATH' is registered as a worktree but the directory is missing on disk."
+    echo "       Recover with: git worktree prune"
     exit 6
   fi
   mkdir -p "$(dirname "$WORKTREE_PATH")"
   git worktree add "$WORKTREE_PATH" -b "<branch>" "origin/$DEFAULT_BRANCH"
   ```
 
-  `WORKTREE_PATH` is stored in the state file and rendered in the step 16 recap exactly as computed above — i.e. an absolute path under the repo root. The `cd <WORKTREE_PATH>` hint then works from any shell regardless of the operator's current directory. Abort cleanly with the structured error above rather than surfacing the raw `git worktree add` error — both failure modes (filesystem clash, stale registration) need to route the operator to the same recovery commands. Use `grep -qxF` so the comparison is a fixed-string exact match on the whole line, avoiding regex / substring false matches when another registered worktree path contains `WORKTREE_PATH` as a substring.
+  `WORKTREE_PATH` is stored in the state file and rendered in the step 16 recap exactly as computed above — i.e. an absolute path under the repo root. The `cd <WORKTREE_PATH>` hint then works from any shell regardless of the operator's current directory. Abort cleanly with the structured error for the detected shape rather than surfacing the raw `git worktree add` error. Use `grep -qxF` so the registry comparison is a fixed-string exact match on the whole line, avoiding regex / substring false matches when another registered worktree path contains `WORKTREE_PATH` as a substring.
 
 In both sub-paths, the branch name (`<branch>`) is the same value computed in step 6 — it already accounts for `--branch=<override>`, so when both `--worktree` and `--branch=<override>` are set the worktree directory is `.worktrees/<override>` (fallback path) or whatever superpowers picked for that branch name (delegated path).
 
@@ -917,7 +932,7 @@ When `lang != "en"`, produce the AskUserQuestion question text, all three option
 | Working tree dirty | Abort. List the dirty files. Tell the user to commit or stash. |
 | Default branch fast-forward fails | Abort. Tell the user to reconcile manually. Never auto-rebase. |
 | Branch already exists | Auto-suffix with today's UTC date and inform the user. |
-| `--worktree` target already exists (fallback path) | Abort with `git worktree remove <path> && git worktree prune` recovery hint (step 13b). Do not auto-clean. |
+| `--worktree` target already exists (fallback path) | Abort with the shape-specific recovery hint from step 13b: `git worktree remove` + `prune` if both on disk and registered; manual `rm`/rename if on disk only (unregistered); `git worktree prune` alone if only the registration is stale. Do not auto-clean. |
 | `--worktree` + superpowers delegation fails | Abort with the skill's error. Operator can retry without `--worktree` for in-place checkout, or uninstall superpowers to hit the fallback. |
 | Reviewer skill missing | Degrade: `gate1` becomes advisory-only, prints a warning, continues. |
 | Kagura missing | Degrade: skip recall and session-start, print a warning, continue. |

--- a/commands/start.md
+++ b/commands/start.md
@@ -599,20 +599,16 @@ This sub-step also runs when `DRY_RUN` is `true` — the operator still sees the
 
 Skip this step entirely if `DRY_RUN` is true.
 
-Fetch the default branch first (both sub-paths need an up-to-date remote ref):
+Each sub-path owns its own remote-refresh step — 13a's `git pull` already performs a fetch, so no shared pre-fetch is needed. Keeping the fetch inside each sub-path also preserves the "no behavior change when `--worktree` is absent" contract for 13a (network calls identical to the pre-`--worktree` version of this step).
 
-```bash
-DEFAULT_BRANCH=<from config>
-git fetch origin "$DEFAULT_BRANCH"
-```
-
-Then branch on `WORKTREE`:
+Branch on `WORKTREE`:
 
 #### 13a. In-place branch (default — `WORKTREE=false`)
 
-Move the current working tree to the default branch, fast-forward, and branch from there:
+Move the current working tree to the default branch, fast-forward, and branch from there. `git pull --ff-only` does its own fetch — no separate `git fetch` needed.
 
 ```bash
+DEFAULT_BRANCH=<from config>
 git checkout "$DEFAULT_BRANCH"
 git pull --ff-only origin "$DEFAULT_BRANCH"
 git checkout -b <branch>
@@ -625,7 +621,14 @@ Set `WORKTREE_PATH=null` (for the state file and recap). The operator continues 
 
 #### 13b. Isolated worktree (`WORKTREE=true`)
 
-The goal is to create the new branch inside a separate working tree so the operator can keep the primary working directory on whatever branch they were on (including — crucially — a feature branch they weren't ready to leave). Base the new worktree off `origin/<DEFAULT_BRANCH>` (already fetched above) — **do not** `git checkout "$DEFAULT_BRANCH"` or run `git pull` in the current worktree, those would forcibly move the operator's primary directory onto the default branch and defeat the purpose of `--worktree`. Fast-forward of the local `<DEFAULT_BRANCH>` pointer is deferred to whenever the operator chooses to update it themselves (typically after merging this PR).
+The goal is to create the new branch inside a separate working tree so the operator can keep the primary working directory on whatever branch they were on (including — crucially — a feature branch they weren't ready to leave). Base the new worktree off `origin/<DEFAULT_BRANCH>` — **do not** `git checkout "$DEFAULT_BRANCH"` or run `git pull` in the current worktree, those would forcibly move the operator's primary directory onto the default branch and defeat the purpose of `--worktree`. Fast-forward of the local `<DEFAULT_BRANCH>` pointer is deferred to whenever the operator chooses to update it themselves (typically after merging this PR).
+
+Refresh the remote-tracking ref before creating the worktree:
+
+```bash
+DEFAULT_BRANCH=<from config>
+git fetch origin "$DEFAULT_BRANCH"
+```
 
 **Probe for `superpowers` plugin** (same method as `commands/doctor.md`'s PMRP step 1 — `ls ~/.claude/plugins/cache/superpowers*` succeeds iff installed):
 

--- a/commands/start.md
+++ b/commands/start.md
@@ -647,17 +647,19 @@ Then choose a path:
 
 - **`SUPERPOWERS_PRESENT=false` — direct fallback**: create the worktree under the repo-local `.worktrees/` convention (gitignored via `/.worktrees/`).
 
+  Anchor paths at the repo root (`git rev-parse --show-toplevel`) so `/start --worktree` behaves correctly regardless of which subdirectory the operator invoked it from. The repo-root `/.worktrees/` gitignore rule is root-anchored, so a worktree accidentally created at `<subdir>/.worktrees/<branch>` would NOT be ignored. Pinning to the repo root also keeps the stale-registration compare (which is against absolute paths from `git worktree list --porcelain`) correct.
+
   Two stale-state footguns exist and must both be detected before calling `git worktree add`:
   1. The target directory already exists on disk (operator left a stale copy behind).
-  2. The directory was manually deleted but the worktree is still registered with git (no filesystem entry, but `git worktree add` will reject with "already registered"). Checking only `[ -e "$WORKTREE_PATH" ]` misses this — the registry must be queried explicitly.
+  2. The directory was manually deleted but the worktree is still registered with git (no filesystem entry, but `git worktree add` will reject with "already registered"). Checking only `[ -e "$WORKTREE_ABS" ]` misses this — the registry must be queried explicitly.
 
   ```bash
-  WORKTREE_PATH=".worktrees/<branch>"
-  WORKTREE_ABS="$(pwd)/$WORKTREE_PATH"
+  REPO_ROOT=$(git rev-parse --show-toplevel)
+  WORKTREE_PATH="$REPO_ROOT/.worktrees/<branch>"   # absolute, anchored to the repo root
   STALE=""
   [ -e "$WORKTREE_PATH" ] && STALE="directory exists on disk"
   if [ -z "$STALE" ] && git worktree list --porcelain 2>/dev/null \
-       | awk '/^worktree /{print $2}' | grep -qxF "$WORKTREE_ABS"; then
+       | awk '/^worktree /{print $2}' | grep -qxF "$WORKTREE_PATH"; then
     STALE="still registered in git worktree list (directory missing on disk)"
   fi
   if [ -n "$STALE" ]; then
@@ -671,7 +673,7 @@ Then choose a path:
   git worktree add "$WORKTREE_PATH" -b "<branch>" "$DEFAULT_BRANCH"
   ```
 
-  Abort cleanly with the structured error above rather than surfacing the raw `git worktree add` error — both failure modes (filesystem clash, stale registration) need to route the operator to the same recovery commands. Use `grep -qxF` so the comparison is a fixed-string exact match on the whole line, avoiding regex / substring false matches when another registered worktree path contains `WORKTREE_ABS` as a substring.
+  `WORKTREE_PATH` is stored in the state file and rendered in the step 16 recap exactly as computed above — i.e. an absolute path under the repo root. The `cd <WORKTREE_PATH>` hint then works from any shell regardless of the operator's current directory. Abort cleanly with the structured error above rather than surfacing the raw `git worktree add` error — both failure modes (filesystem clash, stale registration) need to route the operator to the same recovery commands. Use `grep -qxF` so the comparison is a fixed-string exact match on the whole line, avoiding regex / substring false matches when another registered worktree path contains `WORKTREE_PATH` as a substring.
 
 In both sub-paths, the branch name (`<branch>`) is the same value computed in step 6 — it already accounts for `--branch=<override>`, so when both `--worktree` and `--branch=<override>` are set the worktree directory is `.worktrees/<override>` (fallback path) or whatever superpowers picked for that branch name (delegated path).
 

--- a/commands/start.md
+++ b/commands/start.md
@@ -599,7 +599,7 @@ This sub-step also runs when `DRY_RUN` is `true` — the operator still sees the
 
 Skip this step entirely if `DRY_RUN` is true.
 
-Each sub-path owns its own remote-refresh step — 13a's `git pull` already performs a fetch, so no shared pre-fetch is needed. Keeping the fetch inside each sub-path also preserves the "no behavior change when `--worktree` is absent" contract for 13a (network calls identical to the pre-`--worktree` version of this step).
+Each sub-path owns its own remote-refresh step. In 13a, `git pull` already performs the required fetch, so no shared pre-fetch is needed. Keeping the remote refresh inside each sub-path preserves the default-path flow when `--worktree` is absent without requiring a separate top-level fetch step — 13a's sequence `checkout → pull → checkout -b` is unchanged from the pre-`--worktree` version.
 
 Branch on `WORKTREE`:
 

--- a/commands/start.md
+++ b/commands/start.md
@@ -606,16 +606,17 @@ This sub-step also runs when `DRY_RUN` is `true` — the operator still sees the
 
 Skip this step entirely if `DRY_RUN` is true.
 
-Each sub-path owns its own remote-refresh step. In 13a, `git pull` already performs the required fetch, so no shared pre-fetch is needed. Keeping the remote refresh inside each sub-path preserves the default-path flow when `--worktree` is absent without requiring a separate top-level fetch step — 13a's sequence `checkout → pull → checkout -b` is unchanged from the pre-`--worktree` version.
+Each sub-path owns its own remote-refresh step. In 13a, the sequence is `fetch → checkout → pull → checkout -b` — byte-for-byte identical to the pre-`--worktree` version of this step (the explicit `git fetch` is redundant with the fetch performed by `git pull --ff-only`, but it is preserved verbatim to honor the "no behavior change when `--worktree` is absent" guarantee, down to the network call sequence). 13b uses its own fetch before `git worktree add` so that the worktree is based off a fresh `origin/<DEFAULT_BRANCH>` without touching the current working tree.
 
 Branch on `WORKTREE`:
 
 #### 13a. In-place branch (default — `WORKTREE=false`)
 
-Move the current working tree to the default branch, fast-forward, and branch from there. `git pull --ff-only` does its own fetch — no separate `git fetch` needed.
+Move the current working tree to the default branch, fast-forward, and branch from there. The explicit `git fetch` before `checkout` preserves byte-for-byte parity with the pre-`--worktree` version of this step — `git pull --ff-only` already fetches internally, so the explicit `git fetch` is redundant in terms of refs updated, but keeping it here guarantees the `--worktree`-absent network-call sequence has not changed:
 
 ```bash
 DEFAULT_BRANCH=<from config>
+git fetch origin "$DEFAULT_BRANCH"
 git checkout "$DEFAULT_BRANCH"
 git pull --ff-only origin "$DEFAULT_BRANCH"
 git checkout -b <branch>
@@ -656,6 +657,8 @@ Then choose a path:
   > Set `WORKTREE_PATH=<path the skill used>`.
 
   The leading `/` on the skill name matches the repo's `Invoke the /plugin:command skill via the Skill tool` convention used by every other Skill invocation in this file (`/kagura-memory:session-start`, `/claude-c-suite:ask`, …) — see CONTRIBUTING.md for why this phrasing is load-bearing for reliable Skill-tool routing.
+
+  **Skill-tool failure → degrade, do not abort.** If the Skill invocation fails (skill not found, transient error, the skill reports an error rather than a path), surface the error as a single-line warning (`warning: /superpowers:using-git-worktrees invocation failed — <first line of skill error>; falling back to native git worktree add`) and continue to the `SUPERPOWERS_PRESENT=false` fallback block below. `--worktree` remains usable even when superpowers is installed-but-broken; the operator never has to uninstall a plugin to recover. Only abort if the fallback path itself fails — in which case use the shape-specific recovery from the fallback block.
 
 - **`SUPERPOWERS_PRESENT=false` — direct fallback**: create the worktree under the repo-local `.worktrees/` convention (gitignored via `/.worktrees/`).
 
@@ -942,7 +945,7 @@ When `lang != "en"`, produce the AskUserQuestion question text, all three option
 | Default branch fast-forward fails | Abort. Tell the user to reconcile manually. Never auto-rebase. |
 | Branch already exists | Auto-suffix with today's UTC date and inform the user. |
 | `--worktree` target already exists (fallback path) | Abort with the shape-specific recovery hint from step 13b: `git worktree remove` + `prune` if both on disk and registered; manual `rm`/rename if on disk only (unregistered); `git worktree prune` alone if only the registration is stale. Do not auto-clean. |
-| `--worktree` + superpowers delegation fails | Abort with the skill's error. Operator can retry without `--worktree` for in-place checkout, or uninstall superpowers to hit the fallback. |
+| `--worktree` + superpowers delegation fails | Degrade, do not abort: surface the skill error as a warning and fall through to the native `git worktree add .worktrees/<branch>` fallback (step 13b). Only abort if the fallback path itself fails, in which case use its shape-specific recovery guidance. |
 | Reviewer skill missing | Degrade: `gate1` becomes advisory-only, prints a warning, continues. |
 | Kagura missing | Degrade: skip recall and session-start, print a warning, continue. |
 

--- a/commands/start.md
+++ b/commands/start.md
@@ -659,7 +659,7 @@ Then choose a path:
   STALE=""
   [ -e "$WORKTREE_PATH" ] && STALE="directory exists on disk"
   if [ -z "$STALE" ] && git worktree list --porcelain 2>/dev/null \
-       | awk '/^worktree /{print $2}' | grep -qxF "$WORKTREE_PATH"; then
+       | sed -n 's/^worktree //p' | grep -qxF "$WORKTREE_PATH"; then
     STALE="still registered in git worktree list (directory missing on disk)"
   fi
   if [ -n "$STALE" ]; then

--- a/commands/start.md
+++ b/commands/start.md
@@ -651,7 +651,7 @@ Then choose a path:
 
   Two stale-state footguns exist and must both be detected before calling `git worktree add`:
   1. The target directory already exists on disk (operator left a stale copy behind).
-  2. The directory was manually deleted but the worktree is still registered with git (no filesystem entry, but `git worktree add` will reject with "already registered"). Checking only `[ -e "$WORKTREE_ABS" ]` misses this — the registry must be queried explicitly.
+  2. The directory was manually deleted but the worktree is still registered with git (no filesystem entry, but `git worktree add` will reject with "already registered"). Checking only `[ -e "$WORKTREE_PATH" ]` misses this — the registry must be queried explicitly.
 
   ```bash
   REPO_ROOT=$(git rev-parse --show-toplevel)

--- a/commands/start.md
+++ b/commands/start.md
@@ -5,7 +5,7 @@ arguments:
     description: "One or more GitHub issue identifiers (number, full URL, or owner/repo#number). Multiple IDs create a batch branch. Required (at least one)."
     required: true
   - name: flags
-    description: "Optional space-separated flags: 'dry-run' (skip branch creation, run gate1 only), 'force' (continue past a red gate1 verdict), 'no-memory' (skip Kagura Memory recall and session-start), '--branch=<name>' (override the derived branch name)."
+    description: "Optional space-separated flags: 'dry-run' (skip branch creation, run gate1 only), 'force' (continue past a red gate1 verdict), 'no-memory' (skip Kagura Memory recall and session-start), '--worktree' (create an isolated git worktree at .worktrees/<branch> instead of checking out in-place — delegates to superpowers:using-git-worktrees when installed), '--branch=<name>' (override the derived branch name; combines with --worktree to place the worktree at .worktrees/<override-branch-name>)."
     required: false
 ---
 
@@ -55,7 +55,7 @@ Iterate over `$ARGUMENTS` tokens left-to-right. Each token is classified by **po
   - URL form: `^https://github\.com/.+/.+/issues/[0-9]+$`
   - Short form: `^[^/]+/[^#]+#[0-9]+$`
 - **`--branch=<name>` flag** — matches `^--branch=.+$`. Extract the value after `=` as `BRANCH_OVERRIDE`.
-- **Known flag** — one of: `dry-run`, `force`, `no-memory`
+- **Known flag** — one of: `dry-run`, `force`, `no-memory`, `--worktree`
 - **Unknown** — reject with a clear error listing valid flags and the multi-issue syntax.
 
 All leading tokens that match the issue identifier pattern are collected into the `ISSUE_IDS` list (preserving order). The first token that does NOT match an issue identifier pattern marks the boundary — all remaining tokens are parsed as flags.
@@ -79,6 +79,7 @@ Set booleans from flag tokens:
   - `DRY_RUN=true` if `dry-run` is present
   - `FORCE=true` if `force` is present
   - `NO_MEMORY=true` if `no-memory` is present
+  - `WORKTREE=true` if `--worktree` is present (default: `false`)
   - `BRANCH_OVERRIDE` from `--branch=<value>` if present (default: `null`)
 
 #### 1a. Validate parsed arguments against allow-list
@@ -598,16 +599,70 @@ This sub-step also runs when `DRY_RUN` is `true` — the operator still sees the
 
 Skip this step entirely if `DRY_RUN` is true.
 
+Bring the local default branch up to date in both sub-paths:
+
 ```bash
 DEFAULT_BRANCH=<from config>
 git fetch origin "$DEFAULT_BRANCH"
 git checkout "$DEFAULT_BRANCH"
 git pull --ff-only origin "$DEFAULT_BRANCH"
+```
+
+If `git pull --ff-only` fails (your local default branch has diverged), abort with a clear instruction to reconcile manually. Do not auto-rebase, do not auto-merge.
+
+Then branch on `WORKTREE`:
+
+#### 13a. In-place branch (default — `WORKTREE=false`)
+
+```bash
 git checkout -b <branch>
 git rev-parse --abbrev-ref HEAD  # verify
 ```
 
-If `git pull --ff-only` fails (your local default branch has diverged), abort with a clear instruction to reconcile manually. Do not auto-rebase, do not auto-merge.
+Set `WORKTREE_PATH=null` (for the state file and recap). The operator continues working in the current working directory.
+
+#### 13b. Isolated worktree (`WORKTREE=true`)
+
+The goal is to create the new branch inside a separate working tree so the operator can keep the primary working directory on the default branch (or on another feature branch) while implementation proceeds in the new one.
+
+**Probe for `superpowers` plugin** (same method as `commands/doctor.md`'s PMRP step 1 — `ls ~/.claude/plugins/cache/superpowers*` succeeds iff installed):
+
+```bash
+if ls -d ~/.claude/plugins/cache/superpowers* >/dev/null 2>&1; then
+  SUPERPOWERS_PRESENT=true
+else
+  SUPERPOWERS_PRESENT=false
+fi
+```
+
+Then choose a path:
+
+- **`SUPERPOWERS_PRESENT=true` — delegate to superpowers**:
+
+  > **Invoke the `superpowers:using-git-worktrees` skill via the Skill tool**, asking it to create a worktree for branch `<branch>` off `<DEFAULT_BRANCH>`. Wait for the skill to complete. Capture the resulting worktree path the skill reports (it performs its own smart directory selection and safety checks — the path may or may not be under `.worktrees/`).
+  >
+  > Set `WORKTREE_PATH=<path the skill used>`.
+
+- **`SUPERPOWERS_PRESENT=false` — direct fallback**: create the worktree under the repo-local `.worktrees/` convention (gitignored via `/.worktrees/`).
+
+  ```bash
+  WORKTREE_PATH=".worktrees/<branch>"
+  if [ -e "$WORKTREE_PATH" ]; then
+    echo "error: '$WORKTREE_PATH' already exists — a stale worktree may be present."
+    echo "       Clean it up first, then re-run: git worktree remove '$WORKTREE_PATH' && git worktree prune"
+    echo "       If git reports the worktree is already registered but the directory was manually deleted,"
+    echo "       'git worktree prune' alone is enough."
+    exit 6
+  fi
+  mkdir -p "$(dirname "$WORKTREE_PATH")"
+  git worktree add "$WORKTREE_PATH" -b "<branch>" "$DEFAULT_BRANCH"
+  ```
+
+  Abort cleanly with the error above rather than surfacing the raw `git worktree add` error — this is the most common stale-state footgun for operators, and the error message needs to point directly at the recovery commands.
+
+In both sub-paths, the branch name (`<branch>`) is the same value computed in step 6 — it already accounts for `--branch=<override>`, so when both `--worktree` and `--branch=<override>` are set the worktree directory is `.worktrees/<override>` (fallback path) or whatever superpowers picked for that branch name (delegated path).
+
+Do NOT `cd` into `WORKTREE_PATH` from within this command — the operator's shell is what needs to move, not Claude's virtual working directory. Step 16's recap instructs the operator explicitly.
 
 ### 14. Persist the state file
 
@@ -642,6 +697,7 @@ Write `~/.claude/cache/gh-issue-driven/<branch>.json` using a temp file + atomic
   "branch": "<branch>",
   "branch_type": "<type>",
   "is_batch": <IS_BATCH>,
+  "worktree_path": "<WORKTREE_PATH or null>",
   "started_at": "<UTC ISO-8601>",
   "phase": "designed",
   "gate1": {
@@ -662,7 +718,8 @@ Schema notes:
 - **`issues` array**: contains all issues in input order. Each entry has `number`, `title`, `url`, and `labels`.
 - **`issue_number`, `issue_title`, `issue_url`**: v1-compatible aliases pointing to `issues[0]` (the primary issue). These fields ensure that `ship.md`, `status.md`, and any v1-era state readers continue to work without modification until they adopt the `issues` array.
 - **`is_batch`**: `true` when `len(issues) > 1`, `false` otherwise. Allows downstream commands to branch on batch mode without counting the array.
-- **v1 state files** (created before this change) remain valid — they have `issue_number`/`issue_title` but no `issues` array. Readers should check for `issues` first and fall back to the top-level aliases.
+- **`worktree_path`**: set from step 13b when `--worktree` was used (either the path superpowers returned, or the `.worktrees/<branch>` fallback). `null` when `--worktree` was not used. Readers can use this to render the `cd` hint in `/gh-issue-driven:status` or post-mortem output without re-deriving the path.
+- **v1 state files** (created before this change) remain valid — they have `issue_number`/`issue_title` but no `issues` array and no `worktree_path`. Readers should check for `issues` first and fall back to the top-level aliases; absent `worktree_path` is equivalent to `null`.
 
 `<branch-flat>` is the branch name with `/` replaced by `-` so it works as a filename.
 
@@ -682,6 +739,10 @@ Output exactly one block in this format:
 Issue   #<num> <title>
         <url>
 Branch  <branch>  (created from <default-branch>)
+<if WORKTREE=true:>
+Worktree <WORKTREE_PATH>
+        → cd <WORKTREE_PATH> to work on this branch
+</if>
 Gate1   <verdict> (via /<reviewer>[, escalated to /ceo])
 Memory  <k> related contexts found  (top: "<top summary>" score <score>)
         — or — kagura-memory not installed; skipped
@@ -696,11 +757,17 @@ Issues  #<n1> <title1>
         #<n3> <title3>
         ...
 Branch  <branch>  (created from <default-branch>)
+<if WORKTREE=true:>
+Worktree <WORKTREE_PATH>
+        → cd <WORKTREE_PATH> to work on this branch
+</if>
 Gate1   <verdict> (via /<reviewer>[, escalated to /ceo]) — batch coherence review
 Memory  <k> related contexts found  (top: "<top summary>" score <score>)
         — or — kagura-memory not installed; skipped
         — or — recall returned no results
 ```
+
+The `Worktree` line is printed verbatim from `WORKTREE_PATH` (set in step 13b). When `--worktree` is combined with `--branch=<override>`, `WORKTREE_PATH` already reflects the override (e.g. `.worktrees/<override>`), so the `cd` hint always matches reality. When `--worktree` is absent, both `WORKTREE_PATH` and this entire line block are omitted — the recap stays identical to the pre-`--worktree` output for non-worktree runs.
 
 ### 17. Print implementation guidance
 
@@ -830,6 +897,8 @@ When `lang != "en"`, produce the AskUserQuestion question text, all three option
 | Working tree dirty | Abort. List the dirty files. Tell the user to commit or stash. |
 | Default branch fast-forward fails | Abort. Tell the user to reconcile manually. Never auto-rebase. |
 | Branch already exists | Auto-suffix with today's UTC date and inform the user. |
+| `--worktree` target already exists (fallback path) | Abort with `git worktree remove <path> && git worktree prune` recovery hint (step 13b). Do not auto-clean. |
+| `--worktree` + superpowers delegation fails | Abort with the skill's error. Operator can retry without `--worktree` for in-place checkout, or uninstall superpowers to hit the fallback. |
 | Reviewer skill missing | Degrade: `gate1` becomes advisory-only, prints a warning, continues. |
 | Kagura missing | Degrade: skip recall and session-start, print a warning, continue. |
 


### PR DESCRIPTION
Closes #62

## Summary

- Add an opt-in `--worktree` flag to `/gh-issue-driven:start` so implementation on a new issue can happen in an isolated git worktree rather than in-place, leaving the primary working directory free for concurrent tasks.
- When `superpowers:using-git-worktrees` is installed, delegate path selection to it; otherwise create `.worktrees/<branch>` inside the repo (gitignored).
- `/gh-issue-driven:doctor` gains two aligned checks: `superpowers` plugin presence (same glob probe as `start.md`) and `.gitignore` entry for `/.worktrees/`.
- No behavior change when `--worktree` is absent — the existing `start` → `ship` → `tag` flow is untouched.

## Implementation notes

- `commands/start.md` step 13 splits into `13a` (existing in-place path, semantically identical) and `13b` (new worktree path). The bash for the non-worktree case is moved verbatim under the new sub-header — not rewritten.
- `13b` probes superpowers via `ls -d ~/.claude/plugins/cache/superpowers*`. `doctor.md` step 11 uses the identical glob with a `MUST NOT drift` note in both files. CONTRIBUTING.md codifies this as a design principle ("Presence checks belong in one place").
- State schema gains `worktree_path` (string or null). Absent is equivalent to null, so existing v1/v2 state files remain compatible without migration.
- The recap's `Worktree <path>` + `cd <path>` line is resolved from `WORKTREE_PATH`, so `--worktree` + `--branch=<override>` produces `.worktrees/<override>` (fallback path) and the `cd` hint always matches reality.
- `doctor.md` check 18 (`.gitignore` has `/.worktrees/`) is strictly informational — never the warning / error emoji. It only matters when the operator uses `--worktree` without `superpowers`, and even then the fallback still works.

## Manual verification

Per the issue's AC (new automated tests are out of scope — `tests/*.sh` is static verification only):

- [ ] `a` — `/gh-issue-driven:start <new-issue> --worktree` on a fresh issue without `superpowers` installed: branch created at `.worktrees/<branch>`, recap prints the `cd` hint, state file has `worktree_path` populated.
- [ ] `b` — `/gh-issue-driven:start <new-issue> --worktree --branch=custom`: worktree lands at `.worktrees/custom`, recap hint matches.
- [ ] `c` — `/gh-issue-driven:doctor` with and without `/.worktrees/` in `.gitignore`: check 18 reports present vs. informational-missing. `--fix` hint appends the entry idempotently.
- [ ] `d` — `/gh-issue-driven:start <new-issue>` without the flag: existing in-place behavior is unchanged (non-regression proof).

All existing CI checks pass locally:
- `check-frontmatter.py` → 8/8 command files OK
- `tests/copilot-detection.sh` → 5/5 PASS
- `tests/enum-sync-check.sh` → 24/24 in sync
- `tests/jq-sync-check.sh` → 5/5 in sync
- `tests/test_state_schema.sh` → 39/39 PASS

## Pre-PR review summary

- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: green via /claude-c-suite:ask (DX Lead)
- review provider: copilot

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/62-feat-feat-start-add-worktree-flag-with-gitign.gate1.md
- ~/.claude/cache/gh-issue-driven/62-feat-feat-start-add-worktree-flag-with-gitign.gate2.md

Gate2 advisors also surfaced three low-severity future-observation items (none blocking this PR):
- CSO: consider `git check-ref-format --branch` in `start.md` step 1a as belt-and-suspenders validation for `--branch=<override>`.
- QA Lead: `tests/` could gain a trivial glob-sync check across `start.md` step 13b and `doctor.md` step 11 to enforce the "MUST NOT drift" contract automatically.
- CTO: when a third "same target, two commands" presence-check pattern appears, consider extracting to `commands/_shared/`.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated via /gh-issue-driven:ship
