### PR TITLE
docs: reframe README + repo profile as a Claude Code orchestration harness (#69)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -8,7 +8,9 @@
 
 > **GitHub issue 駆動開発のフルライフサイクルワークフロー: セッションコンテキストからの `propose` → 設計ゲート付き `start` → advisor + Copilot ゲート付き `ship`（全フェーズ境界に HITL 確認）→ リリース儀式自動化 `tag`。マルチ issue バッチ、プラガブル事後レビュア、per-repo Kagura Memory 自動検出付き。**
 
-`gh-issue-driven` は [Claude Code](https://claude.com/claude-code) のプラグインで、「issue #142 の作業を始める」を 1 本の再現可能な 3 フェーズワークフローに変えます:
+`gh-issue-driven` は [Claude Code](https://claude.com/claude-code) のプラグインですが、本質は**オーケストレーション・ハーネス**です。Claude Code 自身のスキルやエージェント（設計レビュア、記憶リコール、`/code-review`、Copilot）を、各フェーズ境界で人間が確認できる 1 本の「Issue → Release」パイプラインに束ねる薄いメタ層です。コードジェネレータでも単発コマンドでもなく、それらのスキルをガバナンスゲートと記憶とともに*編成する*層です。
+
+「issue #142 の作業を始める」を 1 本の再現可能な 3 フェーズワークフローに変えます:
 
 ```mermaid
 graph LR

--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@
 
 > **Full-lifecycle GitHub-issue-driven dev workflow: `propose` issues from session context, design-gated `start`, advisor + Copilot-gated `ship` with HITL confirmation at every phase boundary, ceremony-automated `tag` — with multi-issue batch support, pluggable post-PR reviewer, and per-repo Kagura Memory auto-detect.**
 
-`gh-issue-driven` is a [Claude Code](https://claude.com/claude-code) plugin that turns "I'm starting work on issue #142" into a single, repeatable three-phase workflow:
+`gh-issue-driven` is a [Claude Code](https://claude.com/claude-code) plugin — but think of it as an **orchestration harness**: a thin meta-layer that wires Claude Code's own skills and agents (design advisors, memory recall, `/code-review`, Copilot) into one governed, repeatable issue → release pipeline with a human-in-the-loop checkpoint at every phase boundary. It's **not** a code generator or a single command — it's the layer that *coordinates* those skills with governance gates and memory.
+
+It turns "I'm starting work on issue #142" into a single, repeatable three-phase workflow:
 
 ```mermaid
 graph LR


### PR DESCRIPTION
## What

Reframe the README opening (EN + JA) to position gh-issue-driven as an
**orchestration harness** — a thin meta-layer that wires Claude Code's own
skills/agents (design advisors, memory recall, `/code-review`, Copilot) into one
governed issue → release pipeline with HITL at every phase boundary. "plugin"
stays the distribution noun; it is **not** claimed to "be a skill".

## Repo profile (applied via `gh`, NOT in this diff)

These are direct repo-setting changes (PR-external) and won't appear in the diff:
- **description**: replaced stale "Two-phase…" → "Claude Code orchestration harness for GitHub-issue-driven development: propose → start → ship → tag, …"
- **homepage**: set to the design-philosophy Qiita article
- **topics**: added `claude-code`, `claude-code-plugin`, `github-issues`, `workflow-automation`, `developer-tools`, `code-review`, `github-copilot`, `ai-agents`, `orchestration`

## Scope

README prose only (+ profile via `gh`). No command behavior changes.
Built on merged #67, so positioning copy references `/code-review` consistently.

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)
