### PR TITLE
[codex] Add Codex plugin support

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,44 @@
+{
+  "name": "gh-issue-driven",
+  "version": "0.13.0",
+  "description": "Full-lifecycle GitHub issue driven development workflow for proposing issues, starting branches, shipping PRs, reviewing feedback, and tagging releases.",
+  "author": {
+    "name": "Fumikazu Kiyota",
+    "email": "fumikazu.kiyota@gmail.com",
+    "url": "https://github.com/JFK"
+  },
+  "homepage": "https://github.com/JFK/gh-issue-driven",
+  "repository": "https://github.com/JFK/gh-issue-driven",
+  "license": "MIT",
+  "keywords": [
+    "github",
+    "issues",
+    "pull-requests",
+    "workflow",
+    "code-review",
+    "copilot",
+    "kagura-memory",
+    "milestone",
+    "orchestration",
+    "developer-experience"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "gh-issue-driven",
+    "shortDescription": "Governed GitHub issue to PR and release workflow for Codex.",
+    "longDescription": "Run the gh-issue-driven workflow from Codex: propose GitHub issues, start issue branches with design gates, ship pull requests with review gates, inspect state, and prepare releases.",
+    "developerName": "Fumikazu Kiyota",
+    "category": "Productivity",
+    "capabilities": [
+      "Interactive",
+      "Write"
+    ],
+    "websiteURL": "https://github.com/JFK/gh-issue-driven",
+    "defaultPrompt": [
+      "Run gh-issue-driven doctor",
+      "Start issue 142 with gh-issue-driven",
+      "Ship the current gh-issue-driven branch"
+    ],
+    "brandColor": "#238636"
+  }
+}

--- a/skills/config/SKILL.md
+++ b/skills/config/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: gh-issue-driven-config
+description: "Use when the user asks to run /gh-issue-driven:config, inspect gh-issue-driven settings, initialize the config template, or print a specific config key."
+---
+
+# gh-issue-driven:config
+
+This skill exposes the gh-issue-driven command to Codex.
+
+When invoked:
+
+- Treat the user's request after `gh-issue-driven:config`, `/gh-issue-driven:config`, or `gh-issue-driven config` as the command arguments.
+- Read `../../commands/config.md` and follow it as the source of truth.
+- Preserve the command's trust boundary. In Codex, request permission before writing outside the current workspace or changing durable user configuration.
+- Translate Claude Code command references to available Codex skills or tools when there is a direct equivalent. If a companion plugin is missing, report it and use the fallback behavior specified by the command.

--- a/skills/doctor/SKILL.md
+++ b/skills/doctor/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: gh-issue-driven-doctor
+description: "Use when the user asks to run /gh-issue-driven:doctor, diagnose the gh-issue-driven environment, check GitHub CLI auth, plugin availability, config health, or workflow readiness."
+---
+
+# gh-issue-driven:doctor
+
+This skill exposes the gh-issue-driven command to Codex.
+
+When invoked:
+
+- Treat the user's request after `gh-issue-driven:doctor`, `/gh-issue-driven:doctor`, or `gh-issue-driven doctor` as the command arguments.
+- Read `../../commands/doctor.md` and follow it as the source of truth.
+- Preserve the command's trust boundary. In Codex, request permission before writing outside the current workspace or changing durable user configuration.
+- Translate Claude Code command references to available Codex skills or tools when there is a direct equivalent. If a companion plugin is missing, report it and use the fallback behavior specified by the command.

--- a/skills/goal/SKILL.md
+++ b/skills/goal/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: gh-issue-driven-goal
+description: "Use when the user asks to run /gh-issue-driven:goal, finish a GitHub milestone, or drive multiple milestone issues through start, implementation, ship, and review."
+---
+
+# gh-issue-driven:goal
+
+This skill exposes the gh-issue-driven command to Codex.
+
+When invoked:
+
+- Treat the user's request after `gh-issue-driven:goal`, `/gh-issue-driven:goal`, or `gh-issue-driven goal` as the command arguments.
+- Read `../../commands/goal.md` and follow it as the source of truth.
+- Preserve the command's trust boundary. In Codex, request permission before writing outside the current workspace, changing durable user configuration, or taking destructive git actions.
+- Translate Claude Code command references to available Codex skills or tools when there is a direct equivalent. If a companion plugin is missing, report it and use the fallback behavior specified by the command.

--- a/skills/propose/SKILL.md
+++ b/skills/propose/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: gh-issue-driven-propose
+description: "Use when the user asks to run /gh-issue-driven:propose, turn session context into a GitHub issue, deduplicate issue ideas, or create an issue through the gh-issue-driven workflow."
+---
+
+# gh-issue-driven:propose
+
+This skill exposes the gh-issue-driven command to Codex.
+
+When invoked:
+
+- Treat the user's request after `gh-issue-driven:propose`, `/gh-issue-driven:propose`, or `gh-issue-driven propose` as the command arguments.
+- Read `../../commands/propose.md` and follow it as the source of truth.
+- Preserve the command's trust boundary. In Codex, request permission before writing outside the current workspace, changing durable user configuration, or creating GitHub issues.
+- Translate Claude Code command references to available Codex skills or tools when there is a direct equivalent. If a companion plugin is missing, report it and use the fallback behavior specified by the command.

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: gh-issue-driven-review
+description: "Use when the user asks to run /gh-issue-driven:review, process an existing PR review loop, apply Copilot or code-review feedback, or resume post-PR review."
+---
+
+# gh-issue-driven:review
+
+This skill exposes the gh-issue-driven command to Codex.
+
+When invoked:
+
+- Treat the user's request after `gh-issue-driven:review`, `/gh-issue-driven:review`, or `gh-issue-driven review` as the command arguments.
+- Read `../../commands/review.md` and follow it as the source of truth.
+- Preserve the command's trust boundary. In Codex, request permission before writing outside the current workspace, changing durable user configuration, pushing branches, or editing PR review threads.
+- Translate Claude Code command references to available Codex skills or tools when there is a direct equivalent. If a companion plugin is missing, report it and use the fallback behavior specified by the command.

--- a/skills/ship/SKILL.md
+++ b/skills/ship/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: gh-issue-driven-ship
+description: "Use when the user asks to run /gh-issue-driven:ship, prepare the current issue branch for a PR, run gate2 review, create a pull request, or save session knowledge."
+---
+
+# gh-issue-driven:ship
+
+This skill exposes the gh-issue-driven command to Codex.
+
+When invoked:
+
+- Treat the user's request after `gh-issue-driven:ship`, `/gh-issue-driven:ship`, or `gh-issue-driven ship` as the command arguments.
+- Read `../../commands/ship.md` and follow it as the source of truth.
+- Preserve the command's trust boundary. In Codex, request permission before writing outside the current workspace, changing durable user configuration, creating pull requests, pushing branches, or taking destructive git actions.
+- Translate Claude Code command references to available Codex skills or tools when there is a direct equivalent. If a companion plugin is missing, report it and use the fallback behavior specified by the command.

--- a/skills/start/SKILL.md
+++ b/skills/start/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: gh-issue-driven-start
+description: "Use when the user asks to run /gh-issue-driven:start, start work on one or more GitHub issues, run gate1 design review, create an issue branch, or prepare implementation."
+---
+
+# gh-issue-driven:start
+
+This skill exposes the gh-issue-driven command to Codex.
+
+When invoked:
+
+- Treat the user's request after `gh-issue-driven:start`, `/gh-issue-driven:start`, or `gh-issue-driven start` as the command arguments.
+- Read `../../commands/start.md` and follow it as the source of truth.
+- Preserve the command's trust boundary. In Codex, request permission before writing outside the current workspace, changing durable user configuration, creating branches, or taking destructive git actions.
+- Translate Claude Code command references to available Codex skills or tools when there is a direct equivalent. If a companion plugin is missing, report it and use the fallback behavior specified by the command.

--- a/skills/status/SKILL.md
+++ b/skills/status/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: gh-issue-driven-status
+description: "Use when the user asks to run /gh-issue-driven:status, inspect gh-issue-driven state for the current branch, check gate verdicts, PR status, or Copilot loop progress."
+---
+
+# gh-issue-driven:status
+
+This skill exposes the gh-issue-driven command to Codex.
+
+When invoked:
+
+- Treat the user's request after `gh-issue-driven:status`, `/gh-issue-driven:status`, or `gh-issue-driven status` as the command arguments.
+- Read `../../commands/status.md` and follow it as the source of truth.
+- Preserve the command's trust boundary. This command is read-only unless the referenced source command explicitly says otherwise.
+- Translate Claude Code command references to available Codex skills or tools when there is a direct equivalent. If a companion plugin is missing, report it and use the fallback behavior specified by the command.

--- a/skills/tag/SKILL.md
+++ b/skills/tag/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: gh-issue-driven-tag
+description: "Use when the user asks to run /gh-issue-driven:tag, prepare a release from a milestone, update release notes, bump manifests, create a tag, or create a GitHub release."
+---
+
+# gh-issue-driven:tag
+
+This skill exposes the gh-issue-driven command to Codex.
+
+When invoked:
+
+- Treat the user's request after `gh-issue-driven:tag`, `/gh-issue-driven:tag`, or `gh-issue-driven tag` as the command arguments.
+- Read `../../commands/tag.md` and follow it as the source of truth.
+- Preserve the command's trust boundary. In Codex, request permission before writing outside the current workspace, changing durable user configuration, creating tags, pushing branches, or creating GitHub releases.
+- Translate Claude Code command references to available Codex skills or tools when there is a direct equivalent. If a companion plugin is missing, report it and use the fallback behavior specified by the command.


### PR DESCRIPTION
## Summary

- Add a Codex plugin manifest under `.codex-plugin/plugin.json`.
- Add Codex skill wrappers for the existing gh-issue-driven commands.
- Keep the existing `commands/*.md` files as the source of truth so Claude Code and Codex workflows do not drift.

## Why

This lets Codex install and invoke the gh-issue-driven workflow through the local personal marketplace while preserving the existing Claude Code command definitions.

## Validation

- `python C:\Users\fumik\.codex\skills\.system\plugin-creator\scripts\validate_plugin.py .`