### PR TITLE
test: add decline-token coverage to the verdict-parser contract (#88)

### DIFF
--- a/tests/fixtures/verdicts/expected.json
+++ b/tests/fixtures/verdicts/expected.json
@@ -23,5 +23,8 @@
   "edge-leading-whitespace-verdict-01.md":        {"mode": "advisory", "expected": "yellow"},
   "edge-verdict-with-punctuation-01.md":          {"mode": "advisory", "expected": "yellow"},
   "edge-binary-structured-overrides-heuristic-01.md": {"mode": "binary", "expected": "pass"},
-  "edge-red-heuristic-do-not-proceed-01.md":      {"mode": "advisory", "expected": "red"}
+  "edge-red-heuristic-do-not-proceed-01.md":      {"mode": "advisory", "expected": "red"},
+  "gate1-decline-structured-01.md":               {"mode": "gate1",    "expected": "decline"},
+  "gate1-decline-then-green-01.md":               {"mode": "gate1",    "expected": "green"},
+  "gate1-decline-in-body-01.md":                  {"mode": "gate1",    "expected": "green"}
 }

--- a/tests/fixtures/verdicts/gate1-decline-in-body-01.md
+++ b/tests/fixtures/verdicts/gate1-decline-in-body-01.md
@@ -1,0 +1,6 @@
+# Gate 1 — Design review
+
+The requirements are clear and well-scoped. I briefly weighed whether to
+decline and escalate to /ceo, but a single lens suffices here — there is no
+cross-cutting trade-off to synthesize. The word "decline" appears only as my
+reasoning, never as a structured verdict, so it must NOT trigger escalation.

--- a/tests/fixtures/verdicts/gate1-decline-structured-01.md
+++ b/tests/fixtures/verdicts/gate1-decline-structured-01.md
@@ -1,0 +1,7 @@
+# Gate 1 — Design review
+
+This issue sits at the intersection of security, cost, and architecture, and the
+trade-offs genuinely require synthesis across multiple expert lenses — no single
+reviewer can resolve them well. Escalating is the honest call.
+
+## Verdict: decline

--- a/tests/fixtures/verdicts/gate1-decline-then-green-01.md
+++ b/tests/fixtures/verdicts/gate1-decline-then-green-01.md
@@ -1,0 +1,10 @@
+# Gate 1 — Design review
+
+At first read this looked like it needed multiple lenses.
+
+## Verdict: decline
+
+On reflection, the CTO lens alone is sufficient — the scope is clear and the
+approach is reasonable. Revising my verdict.
+
+## Verdict: green

--- a/tests/test_verdict_parser.py
+++ b/tests/test_verdict_parser.py
@@ -6,9 +6,11 @@ Reference implementation of the gh-issue-driven verdict parser contract.
 Runs against markdown fixtures in tests/fixtures/verdicts/ and validates
 each fixture's parsed verdict against tests/fixtures/verdicts/expected.json.
 
-Two parser modes:
-  - advisory: gate1 + gate2 advisors → green | yellow | red
-  - binary:   gate2 binary gate      → pass | fail
+Three parser modes:
+  - advisory: gate2 advisors (and gate1's green/yellow/red path) → green | yellow | red
+  - binary:   gate2 binary gate                                  → pass | fail
+  - gate1:    gate1 decline-detection (start.md step 10)         → green | yellow | red | decline
+              (`decline` is structured-only — never a heuristic result)
 
 Both modes share the same two-step contract:
   1. Structured verdict line (last wins): ^\\s*##\\s*Verdict:\\s*<token>\\b
@@ -34,6 +36,13 @@ ADVISORY_PATTERN = re.compile(
 
 BINARY_PATTERN = re.compile(
     r"^\s*##\s*Verdict:\s*(pass|fail)\b", re.IGNORECASE | re.MULTILINE
+)
+
+# gate1 emits the advisory tokens PLUS `decline` (the /ceo-escalation signal).
+# This MUST match start.md step 10's expanded scan
+# `^\s*##\s*Verdict:\s*(green|yellow|red|decline)\b`.
+GATE1_PATTERN = re.compile(
+    r"^\s*##\s*Verdict:\s*(green|yellow|red|decline)\b", re.IGNORECASE | re.MULTILINE
 )
 
 # --- Heuristic tokens (step 2 of the contract) ---
@@ -83,6 +92,24 @@ def parse_advisory(text: str) -> str:
 
     # Default
     return "green"
+
+
+def parse_gate1(text: str) -> str:
+    """Parse gate1 verdict: green | yellow | red | decline.
+
+    Used by gate1 (start.md step 10's decline-detection scan). `decline` is the
+    /ceo-escalation signal and is ONLY ever a structured-line token — a free-form
+    mention of "decline" in the reasoning body must NOT trigger it. So the
+    heuristic fallback (no structured line) reuses the advisory classifier, which
+    can never return `decline`.
+    """
+    # Step 1: structured verdict line — last wins (includes decline)
+    matches = GATE1_PATTERN.findall(text)
+    if matches:
+        return matches[-1].lower()
+
+    # Step 2: no structured line — decline is never heuristic; defer to advisory.
+    return parse_advisory(text)
 
 
 def parse_binary(text: str) -> str:
@@ -138,6 +165,8 @@ def main() -> int:
             actual = parse_advisory(text)
         elif mode == "binary":
             actual = parse_binary(text)
+        elif mode == "gate1":
+            actual = parse_gate1(text)
         else:
             print(f"FAIL {filename}: unknown mode '{mode}'")
             failed += 1


### PR DESCRIPTION
Closes #88

## Summary
Add **`decline`-token coverage** to the verdict-parser contract test. The reference parser (`tests/test_verdict_parser.py`) modeled only advisory (`green|yellow|red`) and binary (`pass|fail`), but **gate1 also emits `decline`** (the `/ceo`-escalation signal, `start.md` step 10) — so the contract test and the command had drifted: a structured `## Verdict: decline` was unguarded.

## Implementation notes
- New `gate1` parser mode; `GATE1_PATTERN` mirrors `start.md` step 10 exactly: `^\s*##\s*Verdict:\s*(green|yellow|red|decline)\b`.
- `decline` is **structured-only** — a free-form mention in the reasoning body must not trigger it; the no-structured-line fallback reuses the advisory classifier (which can never return `decline`).
- Three fixtures lock the behavior: `gate1-decline-structured` → `decline`; `gate1-decline-then-green` → `green` (last-wins, no escalation); `gate1-decline-in-body` → `green`.
- **28 fixtures pass** (was 25). Module docstring updated to three modes.

## ⚠️ Scope note (important)
Gate1 (design review) found that **#88 as written is ~90% already implemented**: `tests/test_verdict_parser.py`'s existing 25 fixtures already cover last-wins (`edge-multiple-verdicts`), trailing punctuation (`edge-verdict-with-punctuation`), case-insensitive, leading-whitespace, structured-overrides-heuristic, and both advisory + binary modes; `enum-sync-check.sh` and `jq-sync-check.sh` already cover enum + jq sync in CI. This PR therefore closes the **one genuine remaining gap** — the `decline` token — rather than re-adding existing coverage. The milestone issue was drafted before fully auditing existing test coverage.

## Pre-PR review summary
- gate2 mode: advisor-only (`gate2.binary_gate` = none)
- cso: green / qa-lead: green / cto: green
- gate1: yellow via /claude-c-suite:ask (scoped down — see Scope note)
- review provider: code-review

🤖 Generated via /gh-issue-driven:ship (autonomous=red-only, milestone v0.14.0)
