### PR TITLE
refactor: v0.14.0 verified-safe cleanups (close the inflated compression milestone)

### DIFF
--- a/commands/goal.md
+++ b/commands/goal.md
@@ -177,9 +177,14 @@ Reached on a `red` gate1/gate2 verdict under `red-only` — the sub-command pers
 
 Print the reviewer's findings, then `AskUserQuestion`:
 - **Question**: `Issue #<num>: <phase> returned red. How to proceed?`
-- **"Force-continue this issue"** → **re-invoke the delegated command that returned red, this time with `force`**, so the persisted-but-not-executed work actually happens — do **not** merely "treat as yellow", because under persist-and-return a red gate1 left **no branch** and a red gate2 left **no PR**, so there is nothing to continue *into* yet. Phase-aware:
-  - `phase="gate1"` → re-invoke `/gh-issue-driven:start <issue> --autonomous=<AUTONOMY> force` (red + `force` → `/start` proceeds past gate1 and **creates the branch**), then continue to step 5b (implement) for this issue.
-  - `phase="gate2"` → re-invoke `/gh-issue-driven:ship --autonomous=<AUTONOMY> force` (red + `force` → `/ship` proceeds past gate2 and **creates the PR + runs the delegated `/gh-issue-driven:review` loop**), then continue to step 5e (checkpoint) for this issue. (`force` still does not override a `gate2.binary_gate` `fail` — that remains a non-verdict abort per step 6.)
+- **"Force-continue this issue"** → **re-invoke the delegated command that returned red, this time with `force`** (do **not** merely "treat as yellow" — under persist-and-return a red gate1 left **no branch** and a red gate2 left **no PR**, so there is nothing to continue *into* yet):
+
+  | `phase` | Re-invoke (with `force`) | Effect | Then continue to |
+  |---|---|---|---|
+  | `gate1` | `/gh-issue-driven:start <issue> --autonomous=<AUTONOMY> force` | proceeds past gate1, **creates the branch** | step 5b (implement) |
+  | `gate2` | `/gh-issue-driven:ship --autonomous=<AUTONOMY> force` | proceeds past gate2, **creates the PR + runs the delegated `/gh-issue-driven:review` loop** | step 5e (checkpoint) |
+
+  (`force` still does not override a `gate2.binary_gate` `fail` — that remains a non-verdict abort per step 6.)
 - **"Skip to next issue"** → mark `status="skipped"`, record the red reason in `note`, move on.
 - **"Abort the goal run"** → write state, print recap so far, exit cleanly (resumable later).
 

--- a/commands/start.md
+++ b/commands/start.md
@@ -646,8 +646,6 @@ Store the extracted items as `GATE1_KEY_SUGGESTIONS` — an ordered list of 0–
 
 When `lang != "en"`, localize only the **rendered operator-facing** text: produce the Considerations block, the question text, and all option labels in the language specified by `lang`. If showing advice bullets from `GATE1_KEY_SUGGESTIONS`, translate them for display at render time, but do **not** overwrite or re-store `GATE1_KEY_SUGGESTIONS` in that language.
 
-When `lang != "en"`, produce the Considerations block, the question text, and all option labels in the language specified by `lang`.
-
 Invoke `AskUserQuestion`:
 
 - **Question**: `Gate1 is green. Continue with branch creation?`

--- a/tests/fixtures/token-baseline.txt
+++ b/tests/fixtures/token-baseline.txt
@@ -3,11 +3,11 @@
 # columns: file<TAB>lines<TAB>bytes<TAB>~tokens   (regenerate: bash tests/token-baseline.sh --update)
 config.md	379	30846	7711
 doctor.md	471	27637	6909
-goal.md	241	32295	8073
+goal.md	246	32152	8038
 propose.md	552	24730	6182
 review.md	543	33737	8434
 ship.md	663	48858	12214
-start.md	1107	85109	21277
+start.md	1105	84975	21243
 status.md	192	11918	2979
 tag.md	425	18580	4645
-TOTAL	4573	313710	78424
+TOTAL	4576	313433	78355


### PR DESCRIPTION
Closes #89

## TL;DR
The v0.14.0 "token + precision optimization" milestone was **re-audited against the actual files** (using the token-baseline tool shipped in #94). Its premise turned out to be largely invalid. This PR ships the only **verified-safe, genuinely-beneficial residue** — two small cleanups netting **−69 tokens (−0.09%)**. That negligible number *is* the finding.

## What the re-audit found

**Compression is mostly infeasible**, not "~28% / ~6,400 tokens":
- Slash commands load **whole** — there is no runtime include / conditional load. So "move the size-heuristic to an appendix" saves nothing (the appendix is still in the file), and cross-file dedup (#90, #93) can't reduce runtime tokens without a Read-per-invocation.
- The bulk of `start.md` / `ship.md` is **load-bearing executable spec** (gate contracts, state schema, the `## Verdict:` parser regex, the "Invoke /plugin:command via the Skill tool" phrasing). Compressing it is not a safe token play.

**The precision "bugs" were phantom:**
- #89 step-18b precedence is already an `If / Else if / Else` chain (`start.md:1034-1037`).
- verdict last-wins is already explicit (`start.md:556,575,611`) — and now test-guarded by #95.
- #91 propose.md "invoke both skills in parallel" is **correct** (batched Skill calls are supported — used in this milestone's own gate2 runs).
- #91 propose.md "regex mismatch" is a harmless subset (extraction `[a-z0-9 ]` ⊆ validation `[a-zA-Z0-9 _.:-]`), not a contradiction.

## What this PR actually does (the safe residue)
- **start.md**: delete a verbatim-redundant `lang != "en"` localization line (was line 649) that duplicated line 647.
- **goal.md**: convert the red-verdict force-continue prose into a compact decision table, preserving every load-bearing detail (the `gate2.binary_gate` `fail` exception, phase routing, continue-to steps).
- Refreshed `tests/fixtures/token-baseline.txt` (per the #87 workflow): TOTAL ~78,424 → ~78,355 tokens.

## Milestone disposition
- **#89** — closed by this PR (its only real item was the line-649 dedup).
- **#90 / #91 / #92** — being closed separately with the per-issue verified findings (claims phantom / infeasible / marginal).
- **#93** — converted to a design-discussion issue: it conflicts with the explicit "no `scripts/` directory" principle (CONTRIBUTING.md:24), doesn't reduce runtime tokens, and its "retire jq-sync-check" claim is incorrect.

**The real value of this whole effort already shipped: #94 (the token-baseline measurement tool) and #95 (decline-token parser contract coverage).** Those are worth keeping; the compression headline was not real.

## Verification
- `tests/token-baseline.sh --check` → reductions shown; snapshot refreshed.
- 28/28 verdict-parser fixtures, enum-sync, token-baseline self-test, frontmatter — all green.

🤖 Generated via /gh-issue-driven (milestone v0.14.0 wind-down)
